### PR TITLE
support 'echo_pool' option when creating the engine.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -26,6 +26,9 @@ A list of configuration keys currently understood by the extension:
 ``SQLALCHEMY_ECHO``                If set to `True` SQLAlchemy will log all
                                    the statements issued to stderr which can
                                    be useful for debugging.
+``SQLALCHEMY_ECHO_POOL``           If set to `True`, the connection pool will
+                                   log all checkouts/checkins to the logging
+                                   stream, which defaults to sys.stdout
 ``SQLALCHEMY_RECORD_QUERIES``      Can be used to explicitly disable or
                                    enable query recording.  Query recording
                                    automatically happens in debug or testing

--- a/examples/hello.cfg
+++ b/examples/hello.cfg
@@ -1,4 +1,5 @@
 SQLALCHEMY_DATABASE_URI = 'sqlite:////tmp/test.db'
 SQLALCHEMY_ECHO = False
+SQLALCHEMY_ECHO_POOL = False
 SECRET_KEY = '\xfb\x12\xdf\xa1@i\xd6>V\xc0\xbb\x8fp\x16#Z\x0b\x81\xeb\x16'
 DEBUG = True

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -488,6 +488,7 @@ class _EngineConnector(object):
         with self._lock:
             uri = self.get_uri()
             echo = self._app.config['SQLALCHEMY_ECHO']
+            echo_pool = self._app.config['SQLALCHEMY_ECHO_POOL']
             if (uri, echo) == self._connected_for:
                 return self._engine
             info = make_url(uri)
@@ -496,6 +497,8 @@ class _EngineConnector(object):
             self._sa.apply_driver_hacks(self._app, info, options)
             if echo:
                 options['echo'] = True
+            if echo_pool:
+                options['echo_pool'] = True
             self._engine = rv = sqlalchemy.create_engine(info, **options)
             if _record_queries(self._app):
                 _EngineDebuggingSignalEvents(self._engine,

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -723,6 +723,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_BINDS', None)
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)
         app.config.setdefault('SQLALCHEMY_ECHO', False)
+        app.config.setdefault('SQLALCHEMY_ECHO_POOL', False)
         app.config.setdefault('SQLALCHEMY_RECORD_QUERIES', None)
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)


### PR DESCRIPTION
I would like to add support for turning on the 'echo_pool' option when creating the engine.

http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html#sqlalchemy.create_engine.params.echo_pool
