### PR TITLE
added SQLALCHEMY_DATABASE_OPTIONS to config settings 

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -492,6 +492,9 @@ class _EngineConnector(object):
                 return self._engine
             info = make_url(uri)
             options = {'convert_unicode': True}
+            # allow user to specify additional parameters to the create_engine function
+            if 'SQLALCHEMY_DATABASE_OPTIONS' in self._app.config:
+                options.update(self._app.config['SQLALCHEMY_DATABASE_OPTIONS'])
             self._sa.apply_pool_defaults(self._app, options)
             self._sa.apply_driver_hacks(self._app, info, options)
             if echo:


### PR DESCRIPTION
This allows users to customize their call to create_engine as they need to.  Specifically, this allows me to use SSL for MySQL.  I have it merge into what already exists.

<pre>class DevelopmentConfig(Config):
    SQLALCHEMY_DATABASE_URI = 'mysql+mysqldb://user:password@127.0.0.1/database'
    SQLALCHEMY_DATABASE_OPTIONS = {
        'connect_args': {
            'ssl' : {
                'key': 'ssl/mysql/client-key.pem',
                'cert': 'ssl/mysql/client-cert.pem',
                #'cert': 'ssl/mysql/ca-cert.pem'
            }
        }
    }</pre>
