### PR TITLE
Added a way to specify engine pool class in config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -37,6 +37,10 @@ A list of configuration keys currently understood by the extension:
                                    on some Ubuntu versions) when used with
                                    improper database defaults that specify
                                    encoding-less databases.
+``SQLALCHEMY_POOLCLASS``           The class used by the pool module to provide
+                                   pooling. Defaults to QueuePool. If you are
+                                   using SQLite adapter and pool size None or 0
+                                   will default to NullPool.
 ``SQLALCHEMY_POOL_SIZE``           The size of the database pool.  Defaults
                                    to the engine's default (usually 5)
 ``SQLALCHEMY_POOL_TIMEOUT``        Specifies the connection timeout for the

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -789,6 +789,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)
         app.config.setdefault('SQLALCHEMY_ECHO', False)
         app.config.setdefault('SQLALCHEMY_RECORD_QUERIES', None)
+        app.config.setdefault('SQLALCHEMY_POOLCLASS', None)
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
@@ -828,6 +829,7 @@ class SQLAlchemy(object):
             value = app.config[configkey]
             if value is not None:
                 options[optionkey] = value
+        _setdefault('poolclass', 'SQLALCHEMY_POOLCLASS')
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
@@ -845,7 +847,8 @@ class SQLAlchemy(object):
         """
         if info.drivername.startswith('mysql'):
             info.query.setdefault('charset', 'utf8')
-            if info.drivername != 'mysql+gaerdbms':
+            if info.drivername != 'mysql+gaerdbms' and \
+               options.get('poolclass', None) != sqlalchemy.pool.NullPool:
                 options.setdefault('pool_size', 10)
                 options.setdefault('pool_recycle', 7200)
         elif info.drivername == 'sqlite':


### PR DESCRIPTION
Fixes mitsuhiko/flask-sqlalchemy#266

I didn't like the pool_size == 0 check (https://github.com/mitsuhiko/flask-sqlalchemy/pull/215) because it's a valid option given the SQLAlchemy documentation.
