### PR TITLE
Improve CamelCase->snake_case function

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -590,20 +590,18 @@ class _BoundDeclarativeMeta(DeclarativeMeta):
                 """ Convert a CamelCase string to snake_case """
                 if not name:
                     return ""
-                to_join = []
-                to_join.append(name[0].lower())
-                for prev, c, next in zip(name[:-2], name[1:-1], name[2:]):
-                    if prev.islower() and c.isupper() \
-                       or prev.islower() and c.isdigit() and (next.isupper() or next.isdigit()) \
-                       or (prev.isdigit() or prev.isupper()) and c.isupper() and next.islower():
-                        to_join.append("_" + c.lower())
-                    else:
-                        to_join.append(c.lower())
-                if name[-2:-1].islower() and (name[-1].isupper() or name[-1].isdigit()):
-                    to_join.append("_" + name[-1].lower())
-                else:
-                    to_join.append(name[-1].lower())
-                return "".join(to_join)
+                if len(name) == 1:
+                    return name.lower()
+                return (name[0]
+                        + "".join([("_" + c) \
+                                   if prev.islower() and c.isupper() \
+                                   or prev.islower() and c.isdigit() and (next.isdigit() or next.isupper()) \
+                                   or (prev.isdigit() or prev.isupper()) and c.isupper() and next.islower() \
+                                   else c \
+                                   for prev, c, next in zip(name[:-2], name[1:-1], name[2:])])
+                        + ("_" + name[-1]
+                           if name[-2:-1].islower() and (name[-1].isupper() or name[-1].isdigit())
+                           else name[-1])).lower()
             d['__tablename__'] = _camel_to_snake(name)
 
         return DeclarativeMeta.__new__(cls, name, bases, d)

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -47,7 +47,6 @@ __version__ = '3.0-dev'
 connection_stack = _app_ctx_stack or _request_ctx_stack
 
 
-_camelcase_re = re.compile(r'([A-Z]+)(?=[a-z0-9])')
 _signals = Namespace()
 
 
@@ -587,12 +586,25 @@ class _BoundDeclarativeMeta(DeclarativeMeta):
 
     def __new__(cls, name, bases, d):
         if _should_set_tablename(bases, d):
-            def _join(match):
-                word = match.group()
-                if len(word) > 1:
-                    return ('_%s_%s' % (word[:-1], word[-1])).lower()
-                return '_' + word.lower()
-            d['__tablename__'] = _camelcase_re.sub(_join, name).lstrip('_')
+            def _camel_to_snake(name):
+                """ Convert a CamelCase string to snake_case """
+                if not name:
+                    return ""
+                to_join = []
+                to_join.append(name[0].lower())
+                for prev, c, next in zip(name[:-2], name[1:-1], name[2:]):
+                    if prev.islower() and c.isupper() \
+                       or prev.islower() and c.isdigit() and (next.isupper() or next.isdigit()) \
+                       or (prev.isdigit() or prev.isupper()) and c.isupper() and next.islower():
+                        to_join.append("_" + c.lower())
+                    else:
+                        to_join.append(c.lower())
+                if name[-2:-1].islower() and (name[-1].isupper() or name[-1].isdigit()):
+                    to_join.append("_" + name[-1].lower())
+                else:
+                    to_join.append(name[-1].lower())
+                return "".join(to_join)
+            d['__tablename__'] = _camel_to_snake(name)
 
         return DeclarativeMeta.__new__(cls, name, bases, d)
 

--- a/test_sqlalchemy.py
+++ b/test_sqlalchemy.py
@@ -236,11 +236,16 @@ class TablenameTestCase(unittest.TestCase):
         class BazBar(db.Model):
             id = db.Column(db.Integer, primary_key=True)
 
+        class LONGName4TestingCamelCase2snake_caseALGORithm22BBQ2(db.Model):
+            id = db.Column(db.Integer, primary_key=True)
+
         class Ham(db.Model):
             __tablename__ = 'spam'
             id = db.Column(db.Integer, primary_key=True)
 
         self.assertEqual(FOOBar.__tablename__, 'foo_bar')
+        self.assertEqual(LONGName4TestingCamelCase2snake_caseALGORithm22BBQ2.__tablename__,
+                         'long_name_4_testing_camel_case2snake_case_algo_rithm_22bbq2')
         self.assertEqual(BazBar.__tablename__, 'baz_bar')
         self.assertEqual(Ham.__tablename__, 'spam')
 


### PR DESCRIPTION
The current CamelCase->snake_case function is incorrect when working
with acronyms and numbers in words. This caused a pretty interesting
bug hunt today at work.

Examples (old and proposed method):

`VP9Codec` -> `v_p9_codec` (old)
`VP9Codec` -> `vp9_codec` (proposed)

`HTTP2RequestSession` -> `htt_p2_request_session` (old)
`HTTP2RequestSession` -> `http2_request_session` (proposed)

`UserST4` -> `user_s_t4` (old)
`UserST4` -> `user_st4` (proposed)

`HTTP2ClientType3EncoderParametersSSE`
-> `htt_p2_client_type3_encoder_parametersSSE` (old)
-> `http2_client_type_3_encoder_parameters_sse` (proposed)