### PR TITLE
Allow for arbitrary Pool configuration

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -63,6 +63,12 @@ A list of configuration keys currently understood by the extension:
                                    that it will be disabled by default in
                                    the future.  This requires extra memory
                                    and should be disabled if not needed.
+``SQLALCHEMY_POOL``                A reference to a SQLAlchemy Pool object,
+                                   when used, other pool-related
+                                   configuration elements will be
+                                   disregarded in favor of this pool object.
+                                   This allows for the full flexibility
+                                   that SQLAlchemy provides around pools.
 ================================== =========================================
 
 .. versionadded:: 0.8

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -536,7 +536,11 @@ class _EngineConnector(object):
                 return self._engine
             info = make_url(uri)
             options = {'convert_unicode': True}
-            self._sa.apply_pool_defaults(self._app, options)
+            pool = self._app.config['SQLALCHEMY_POOL']
+            if pool:
+                options['pool'] = pool
+            else:
+                self._sa.apply_pool_defaults(self._app, options)
             self._sa.apply_driver_hacks(self._app, info, options)
             if echo:
                 options['echo'] = echo
@@ -830,6 +834,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
+        app.config.setdefault('SQLALCHEMY_POOL', None)
         track_modifications = app.config.setdefault(
             'SQLALCHEMY_TRACK_MODIFICATIONS', None
         )


### PR DESCRIPTION
I was looking for more flexibility around pools and this hook should
allow for users to pass whatever pool object they want to use.