### PR TITLE
fix: maybe we should not modify `app.config`

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -827,8 +827,6 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_RECORD_QUERIES', None)
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
-        app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
-        app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
         track_modifications = app.config.setdefault(
             'SQLALCHEMY_TRACK_MODIFICATIONS', None
@@ -854,7 +852,7 @@ class SQLAlchemy(object):
 
     def apply_pool_defaults(self, app, options):
         def _setdefault(optionkey, configkey):
-            value = app.config[configkey]
+            value = app.config.get(configkey)
             if value is not None:
                 options[optionkey] = value
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
@@ -1034,3 +1032,4 @@ class FSADeprecationWarning(DeprecationWarning):
 
 
 warnings.simplefilter('always', FSADeprecationWarning)
+


### PR DESCRIPTION
```sh
$ cat web.config
SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://******?charset=utf8'
```

```py
app = flask.Flask(__name__)
app.config.from_pyfile('web.config')
db = SQLAlchemy(app)
sqlengine = sqlalchemy.create_engine(app.config['SQLALCHEMY_DATABASE_URI'],
    pool_recycle=app.config.get('SQLALCHEMY_POOL_RECYCLE', 7200),  # pool_recycle is None! BAD!
    max_overflow=app.config.get('SQLALCHEMY_MAX_OVERFLOW', -1)) # max_overflow is None! BAD!
conn = sqlengine.connect()  # TERRIBLE!
```