### PR TITLE
Replace app.root_path with app.instance_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
 -   Remove default ``'sqlite:///:memory:'`` setting for
     ``SQLALCHEMY_DATABASE_URI``, raise error when both it and
     ``SQLALCHEMY_BINDS`` are unset. :pr:`731`
+-   Configuring SQLite with a relative path is relative to
+    ``app.instance_path`` instead of ``app.root_path``. The instance
+    folder is created if necessary. :issue:`462`
 
 
 Version 2.4.2

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -884,7 +884,7 @@ class SQLAlchemy:
 
             # if it's not an in memory database we make the path absolute.
             if not detected_in_memory:
-                sa_url.database = os.path.join(app.root_path, sa_url.database)
+                sa_url.database = os.path.join(app.instance_path, sa_url.database)
 
     @property
     def engine(self):

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -882,8 +882,10 @@ class SQLAlchemy:
 
                 options["poolclass"] = NullPool
 
-            # if it's not an in memory database we make the path absolute.
-            if not detected_in_memory:
+            # If the database path is not absolute, it's relative to the
+            # app instance path, which might need to be created.
+            if not detected_in_memory and not os.path.isabs(sa_url.database):
+                os.makedirs(app.instance_path, exist_ok=True)
                 sa_url.database = os.path.join(app.instance_path, sa_url.database)
 
     @property


### PR DESCRIPTION
Our microservices have deployment folders (with configuration files) that are separate from the repository folders. 

- The default sqlalchemy behavior for a relative sqlite path is to use the current working directory.
- However, flask-sqlalchemy assumes that all relative sqlite paths are relative to `app.root_path` and the resulting sqlite file ends up in the repository folder. Currently, we are using the following workaround to recreate the default sqlalchemy behavior:

```
    SQLALCHEMY_DATABASE_URI = 'sqlite:///{data_folder}/database.sqlite'
    APP.config['SQLALCHEMY_DATABASE_URI'] = APP.config[
        'SQLALCHEMY_DATABASE_URI'].format(data_folder=os.getcwd())
```

As of 0.8, flask supports [instance folders](http://flask.pocoo.org/docs/0.12/config/#instance-folders). The proposed fix is to replace `app.root_path` with `app.instance_path`, which will let us customize the application instance folder when initializing flask.

fixes #462