### PR TITLE
Support additional SQLAlchemy parameters.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,56 +14,73 @@ A list of configuration keys currently understood by the extension:
 
 .. tabularcolumns:: |p{6.5cm}|p{8.5cm}|
 
-================================== =========================================
-``SQLALCHEMY_DATABASE_URI``        The database URI that should be used for
-                                   the connection.  Examples:
+=================================== =========================================
+``SQLALCHEMY_DATABASE_URI``         The database URI that should be used for
+                                    the connection.  Examples:
 
-                                   - ``sqlite:////tmp/test.db``
-                                   - ``mysql://username:password@server/db``
-``SQLALCHEMY_BINDS``               A dictionary that maps bind keys to
-                                   SQLAlchemy connection URIs.  For more
-                                   information about binds see :ref:`binds`.
-``SQLALCHEMY_ECHO``                If set to `True` SQLAlchemy will log all
-                                   the statements issued to stderr which can
-                                   be useful for debugging.
-``SQLALCHEMY_RECORD_QUERIES``      Can be used to explicitly disable or
-                                   enable query recording.  Query recording
-                                   automatically happens in debug or testing
-                                   mode.  See :func:`get_debug_queries` for
-                                   more information.
-``SQLALCHEMY_NATIVE_UNICODE``      Can be used to explicitly disable native
-                                   unicode support.  This is required for
-                                   some database adapters (like PostgreSQL
-                                   on some Ubuntu versions) when used with
-                                   improper database defaults that specify
-                                   encoding-less databases.
-``SQLALCHEMY_POOL_SIZE``           The size of the database pool.  Defaults
-                                   to the engine's default (usually 5)
-``SQLALCHEMY_POOL_TIMEOUT``        Specifies the connection timeout for the
-                                   pool.  Defaults to 10.
-``SQLALCHEMY_POOL_RECYCLE``        Number of seconds after which a
-                                   connection is automatically recycled.
-                                   This is required for MySQL, which removes
-                                   connections after 8 hours idle by
-                                   default.  Note that Flask-SQLAlchemy
-                                   automatically sets this to 2 hours if
-                                   MySQL is used. Some backends may use a 
-                                   different default timeout value. For more 
-                                   information about timeouts see 
-                                   :ref:`timeouts`.
-``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
-                                   can be created after the pool reached
-                                   its maximum size.  When those additional
-                                   connections are returned to the pool,
-                                   they are disconnected and discarded.
-``SQLALCHEMY_TRACK_MODIFICATIONS`` If set to ``True``, Flask-SQLAlchemy will
-                                   track modifications of objects and emit
-                                   signals.  The default is ``None``, which
-                                   enables tracking but issues a warning
-                                   that it will be disabled by default in
-                                   the future.  This requires extra memory
-                                   and should be disabled if not needed.
-================================== =========================================
+                                    - ``sqlite:////tmp/test.db``
+                                    - ``mysql://username:password@server/db``
+``SQLALCHEMY_BINDS``                A dictionary that maps bind keys to
+                                    SQLAlchemy connection URIs.  For more
+                                    information about binds see :ref:`binds`.
+``SQLALCHEMY_ECHO``                 If set to `True` SQLAlchemy will log all
+                                    the statements issued to stderr which can
+                                    be useful for debugging.
+``SQLALCHEMY_RECORD_QUERIES``       Can be used to explicitly disable or
+                                    enable query recording.  Query recording
+                                    automatically happens in debug or testing
+                                    mode.  See :func:`get_debug_queries` for
+                                    more information.
+``SQLALCHEMY_NATIVE_UNICODE``       Can be used to explicitly disable native
+                                    unicode support.  This is required for
+                                    some database adapters (like PostgreSQL
+                                    on some Ubuntu versions) when used with
+                                    improper database defaults that specify
+                                    encoding-less databases.
+``SQLALCHEMY_POOL_SIZE``            The size of the database pool.  Defaults
+                                    to the engine's default (usually 5)
+``SQLALCHEMY_POOL_TIMEOUT``         Specifies the connection timeout for the
+                                    pool.  Defaults to 10.
+``SQLALCHEMY_POOL_RECYCLE``         Number of seconds after which a
+                                    connection is automatically recycled.
+                                    This is required for MySQL, which removes
+                                    connections after 8 hours idle by
+                                    default.  Note that Flask-SQLAlchemy
+                                    automatically sets this to 2 hours if
+                                    MySQL is used. Some backends may use a
+                                    different default timeout value. For more
+                                    information about timeouts see
+                                    :ref:`timeouts`.
+``SQLALCHEMY_MAX_OVERFLOW``         Controls the number of connections that
+                                    can be created after the pool reached
+                                    its maximum size.  When those additional
+                                    connections are returned to the pool,
+                                    they are disconnected and discarded.
+``SQLALCHEMY_TRACK_MODIFICATIONS``  If set to ``True``, Flask-SQLAlchemy will
+                                    track modifications of objects and emit
+                                    signals.  The default is ``None``, which
+                                    enables tracking but issues a warning
+                                    that it will be disabled by default in
+                                    the future.  This requires extra memory
+                                    and should be disabled if not needed.
+``SQLALCHEMY_CREATOR``              Can be used to bring a creator function
+                                    which returns a DBAPI connection. The
+                                    underlying connection pool will use this
+                                    function to create all new database
+                                    connections.
+``SQLALCHEMY_ECHO_POOL``            If set to ``True``, the connection pool will
+                                    log all checkouts/checkins to the logging
+                                    stream.
+``SQLALCHEMY_POOL_PRE_PING``        If set to ``True``, the connection pool will
+                                    test whether connections are live upon each
+                                    checkout.
+
+                                    .. Warning::
+                                       You must have SQLAlchemy 1.2+ to use
+                                       this option
+``SQLALCHEMY_POOL_RESET_ON_RETURN`` Can be used to set a default action when
+                                    connections are returned to the pool.
+=================================== =========================================
 
 .. versionadded:: 0.8
    The ``SQLALCHEMY_NATIVE_UNICODE``, ``SQLALCHEMY_POOL_SIZE``,

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -835,6 +835,10 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
+        app.config.setdefault('SQLALCHEMY_CREATOR', None)
+        app.config.setdefault('SQLALCHEMY_ECHO_POOL', None)
+        app.config.setdefault('SQLALCHEMY_POOL_PRE_PING', None)
+        app.config.setdefault('SQLALCHEMY_POOL_RESET_ON_RETURN', None)
         track_modifications = app.config.setdefault(
             'SQLALCHEMY_TRACK_MODIFICATIONS', None
         )
@@ -866,6 +870,10 @@ class SQLAlchemy(object):
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
         _setdefault('max_overflow', 'SQLALCHEMY_MAX_OVERFLOW')
+        _setdefault('creator', 'SQLALCHEMY_CREATOR')
+        _setdefault('echo_pool', 'SQLALCHEMY_ECHO_POOL')
+        _setdefault('pool_pre_ping', 'SQLALCHEMY_POOL_PRE_PING')
+        _setdefault('pool_reset_on_return', 'SQLALCHEMY_POOL_RESET_ON_RETURN')
 
     def apply_driver_hacks(self, app, info, options):
         """This method is called before engine creation and used to inject


### PR DESCRIPTION
I found some SQLAlchemy parameters are helpful when we have unreliable network connectivity between applications and database.
* `creator` helps to create custom DBAPI connections.
* `echo_pool` will log all check-ins/outs of the pool.
* `pool_pre_ping` tests connections for linveness upon each checkout.
* `pool_reset_on_return` allows to override default behavior upon return.

By default, all those options are turned off (or following the default behavior in SQLAlchemy) for backward compatibility.

For more information about the parameters, please refer to the following official SQLAlchemy documentation:
http://docs.sqlalchemy.org/en/latest/core/engines.html#engine-creation-api