### PR TITLE
Specifying the poolclass argument manually.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -38,7 +38,7 @@ A list of configuration keys currently understood by the extension:
                                    improper database defaults that specify
                                    encoding-less databases.
 ``SQLALCHEMY_POOL_CLASS``          This argument accepts a class imported from
-                                   the sqlalchemy.pool module. Common options include specifying QueuePool or NullPool
+                                   the sqlalchemy.pool module. Such as Pool, QueuePool, SingletonThreadPool, StaticPool or NullPool
 ``SQLALCHEMY_POOL_SIZE``           The size of the database pool.  Defaults
                                    to the engine's default (usually 5)
 ``SQLALCHEMY_POOL_TIMEOUT``        Specifies the connection timeout for the

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -37,6 +37,8 @@ A list of configuration keys currently understood by the extension:
                                    on some Ubuntu versions) when used with
                                    improper database defaults that specify
                                    encoding-less databases.
+``SQLALCHEMY_POOL_CLASS``          This argument accepts a class imported from
+                                   the sqlalchemy.pool module. Common options include specifying QueuePool or NullPool
 ``SQLALCHEMY_POOL_SIZE``           The size of the database pool.  Defaults
                                    to the engine's default (usually 5)
 ``SQLALCHEMY_POOL_TIMEOUT``        Specifies the connection timeout for the

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -830,6 +830,7 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)
         app.config.setdefault('SQLALCHEMY_ECHO', False)
         app.config.setdefault('SQLALCHEMY_RECORD_QUERIES', None)
+        app.config.setdefault('SQLALCHEMY_POOL_CLASS', None)
         app.config.setdefault('SQLALCHEMY_POOL_SIZE', None)
         app.config.setdefault('SQLALCHEMY_POOL_TIMEOUT', None)
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
@@ -862,6 +863,7 @@ class SQLAlchemy(object):
             value = app.config[configkey]
             if value is not None:
                 options[optionkey] = value
+        _setdefault('poolclass', 'SQLALCHEMY_POOL_CLASS')
         _setdefault('pool_size', 'SQLALCHEMY_POOL_SIZE')
         _setdefault('pool_timeout', 'SQLALCHEMY_POOL_TIMEOUT')
         _setdefault('pool_recycle', 'SQLALCHEMY_POOL_RECYCLE')
@@ -880,8 +882,10 @@ class SQLAlchemy(object):
         if info.drivername.startswith('mysql'):
             info.query.setdefault('charset', 'utf8')
             if info.drivername != 'mysql+gaerdbms':
-                options.setdefault('pool_size', 10)
-                options.setdefault('pool_recycle', 7200)
+                from sqlalchemy.pool import NullPool
+                if options.get('poolclass', None) != NullPool:
+                    options.setdefault('pool_size', 10)
+                    options.setdefault('pool_recycle', 7200)
         elif info.drivername == 'sqlite':
             pool_size = options.get('pool_size')
             detected_in_memory = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ def app(request):
     app.testing = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    from sqlalchemy.pool import NullPool
+    app.config['SQLALCHEMY_POOL_CLASS'] = NullPool
     return app
 
 


### PR DESCRIPTION
In my case, our one of databases which is based on SQL Server would close every mid night.
By default, the poolclass was set, but the query would failed if the database was restarted. 
Because the connection was still in memory for efficient reuse, it thought the database was still active.