### PR TITLE
Retrieve all items without limit in pagination

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -497,7 +497,7 @@ class BaseQuery(orm.Query):
         else:
             items = self.limit(per_page).offset((page - 1) * per_page).all()
 
-        if not items or per_page == 0 and page != 1 and error_out:
+        if (not items or per_page == 0) and page != 1 and error_out:
             abort(404)
 
         # No need to count if we're on the first page and there are fewer


### PR DESCRIPTION
Hi.

Sometimes, i need retrieve all items and use big limit, for example limit=9999999. I think is not practical. This commit can do this case more easy.