### PR TITLE
Pagination dict() support

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -322,6 +322,12 @@ class Pagination(object):
         #: the items for the current page
         self.items = items
 
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def keys(self):
+        return ('page', 'pages', 'total', 'has_prev', 'next_num', 'has_next', 'items')
+
     @property
     def pages(self):
         """The total number of pages"""


### PR DESCRIPTION
For issue https://github.com/mitsuhiko/flask-sqlalchemy/issues/482 

Credit goes to @protream, I just implemented

Now you can do this: 
```
>>> p = Pagination('a',1,20,100,[])
>>> dict(p)
{'page': 1, 'pages': 5, 'total': 100, 'has_prev': False, 'next_num': 2, 'has_next': True, 'items': []}
>>> p['page']
1
```
  