### PR TITLE
Fix exception in example on first run

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -57,4 +57,5 @@ def update_done():
 
 
 if __name__ == '__main__':
+    db.create_all()
     app.run()


### PR DESCRIPTION
This adds `db.create_all()` to the main block of the example code. Otherwise, database operations error on the first run because none of the tables exist.