### PR TITLE
Add description args for description of abort()

### DIFF
--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -126,3 +126,8 @@ This will raise 404 errors instead of returning `None`::
     def show_user(username):
         user = User.query.filter_by(username=username).first_or_404()
         return render_template('show_user.html', user=user)
+
+
+Also, if you want to add a description with abort(), you can use it as argument as well.
+
+>>> User.query.filter_by(username=username).first_or_404(description='There is no data with {}'.format(username))

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -414,20 +414,20 @@ class BaseQuery(orm.Query):
     Override the query class for an individual model by subclassing this and setting :attr:`~Model.query_class`.
     """
 
-    def get_or_404(self, ident):
+    def get_or_404(self, ident, description=None):
         """Like :meth:`get` but aborts with 404 if not found instead of returning ``None``."""
 
         rv = self.get(ident)
         if rv is None:
-            abort(404)
+            abort(404, description=description)
         return rv
 
-    def first_or_404(self):
+    def first_or_404(self, description=None):
         """Like :meth:`first` but aborts with 404 if not found instead of returning ``None``."""
 
         rv = self.first()
         if rv is None:
-            abort(404)
+            abort(404, description=description)
         return rv
 
     def paginate(self, page=None, per_page=None, error_out=True, max_per_page=None):

--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -1,4 +1,5 @@
 import pytest
+from werkzeug.exceptions import NotFound
 
 import flask_sqlalchemy as fsa
 
@@ -28,3 +29,27 @@ def test_app_bound(db, Todo):
     db.session.add(todo)
     db.session.commit()
     assert len(Todo.query.all()) == 1
+
+
+def test_get_or_404(Todo):
+    with pytest.raises(NotFound):
+        Todo.query.get_or_404(1)
+
+    expected = 'Expected message'
+
+    with pytest.raises(NotFound) as e_info:
+        Todo.query.get_or_404(1, description=expected)
+
+    assert e_info.value.description == expected
+
+
+def test_first_or_404(Todo):
+    with pytest.raises(NotFound):
+        Todo.query.first_or_404()
+
+    expected = 'Expected message'
+
+    with pytest.raises(NotFound) as e_info:
+        Todo.query.first_or_404(description=expected)
+
+    assert e_info.value.description == expected


### PR DESCRIPTION
Originally, `get_or_404` or `first_or_404` couldn't send the description about why that error happened. So I propose to add the description to the all `or_404` functions.