### PR TITLE
replace time.clock with perf_counter for py3

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -36,7 +36,10 @@ __version__ = '2.3.2'
 
 # the best timer function for the platform
 if sys.platform == 'win32':
-    _timer = time.clock
+    if sys.version_info >= (3, 3):
+        _timer = time.perf_counter
+    else:
+        _timer = time.clock
 else:
     _timer = time.time
 


### PR DESCRIPTION
Replace the timer to suppress the deprecation warning.