### PR TITLE
Prevent usage of query property helper on result row

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -517,7 +517,7 @@ class _QueryProperty(object):
         self.sa = sa
 
     def __get__(self, obj, type):
-        if obj is not None and obj.__class__.__bases__[0].query is None:
+        if obj is not None:
             raise AttributeError('The query property is only accessible from '
                                  'a model class, not an instance.')
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -518,8 +518,10 @@ class _QueryProperty(object):
 
     def __get__(self, obj, type):
         if obj is not None:
-            raise AttributeError('The query property is only accessible from '
-                                 'a model class, not an instance.')
+            warnings.warn(FSADeprecationWarning(
+                'The query property is only accessible from a model class, '
+                'not an instance.'
+            ))
 
         try:
             mapper = orm.class_mapper(type)

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -520,9 +520,14 @@ class _QueryProperty(object):
         try:
             mapper = orm.class_mapper(type)
             if mapper:
-                return type.query_class(mapper, session=self.sa.session())
+                query = type.query_class(mapper, session=self.sa.session())
         except UnmappedClassError:
-            return None
+            query = None
+
+        if obj is not None and not obj.__class__.__bases__[0].query:
+            raise RuntimeError('Only use BaseQuery helper from a model class.')
+
+        return query
 
 
 def _record_queries(app):

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -517,17 +517,16 @@ class _QueryProperty(object):
         self.sa = sa
 
     def __get__(self, obj, type):
+        if obj is not None and obj.__class__.__bases__[0].query is None:
+            raise AttributeError('The query property is only accessible from '
+                                 'a model class, not an instance.')
+
         try:
             mapper = orm.class_mapper(type)
             if mapper:
-                query = type.query_class(mapper, session=self.sa.session())
+                return type.query_class(mapper, session=self.sa.session())
         except UnmappedClassError:
-            query = None
-
-        if obj is not None and not obj.__class__.__bases__[0].query:
-            raise RuntimeError('Only use BaseQuery helper from a model class.')
-
-        return query
+            return None
 
 
 def _record_queries(app):

--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -36,7 +36,7 @@ def test_query_forbidden_from_result_row(db, Todo):
     db.session.add(todo)
     db.session.commit()
     row = Todo.query.first()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AttributeError):
         row.query.first()
 
 

--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -31,6 +31,15 @@ def test_app_bound(db, Todo):
     assert len(Todo.query.all()) == 1
 
 
+def test_query_forbidden_from_result_row(db, Todo):
+    todo = Todo('Test', 'test')
+    db.session.add(todo)
+    db.session.commit()
+    row = Todo.query.first()
+    with pytest.raises(RuntimeError):
+        row.query.first()
+
+
 def test_get_or_404(Todo):
     with pytest.raises(NotFound):
         Todo.query.get_or_404(1)

--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -31,12 +31,12 @@ def test_app_bound(db, Todo):
     assert len(Todo.query.all()) == 1
 
 
-def test_query_forbidden_from_result_row(db, Todo):
+def test_query_on_instance_deprecated(db, Todo):
     todo = Todo('Test', 'test')
     db.session.add(todo)
     db.session.commit()
     row = Todo.query.first()
-    with pytest.raises(AttributeError):
+    with pytest.warns(fsa.FSADeprecationWarning):
         row.query.first()
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -64,7 +64,7 @@ def test_joined_inheritance_relation(db):
     db.session.add(base)
     db.session.commit()
 
-    base = Base.query.one()
+    base = SubBase.query.one()
 
 
 def test_connection_binds(db):

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -64,7 +64,7 @@ def test_joined_inheritance_relation(db):
     db.session.add(base)
     db.session.commit()
 
-    base = base.query.one()
+    base = Base.query.one()
 
 
 def test_connection_binds(db):


### PR DESCRIPTION
Fixes #649.

Prevents incorrectly using `Model.query` helper from a result row, for ex: `User.query.first().query`