### PR TITLE
make SA engine configuration more flexible

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: flask_sqlalchemy
+
 Configuration
 =============
 
@@ -63,6 +65,9 @@ A list of configuration keys currently understood by the extension:
                                    that it will be disabled by default in
                                    the future.  This requires extra memory
                                    and should be disabled if not needed.
+``SQLALCHEMY_ENGINE_OPTIONS``      A dictionary of keyword args to send to
+                                   :func:`~sqlalchemy.create_engine`.  See
+                                   also ``engine_options`` to :class:`SQLAlchemy`.
 ================================== =========================================
 
 .. versionadded:: 0.8
@@ -78,8 +83,12 @@ A list of configuration keys currently understood by the extension:
 
 .. versionadded:: 2.0
    The ``SQLALCHEMY_TRACK_MODIFICATIONS`` configuration key was added.
+
 .. versionchanged:: 2.1
    ``SQLALCHEMY_TRACK_MODIFICATIONS`` will warn if unset.
+
+.. versionchanged:: 2.4
+   ``SQLALCHEMY_ENGINE_OPTIONS`` configuration key was added.
 
 Connection URI Format
 ---------------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -39,10 +39,16 @@ A list of configuration keys currently understood by the extension:
                                    on some Ubuntu versions) when used with
                                    improper database defaults that specify
                                    encoding-less databases.
+
+                                   **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_POOL_SIZE``           The size of the database pool.  Defaults
-                                   to the engine's default (usually 5)
+                                   to the engine's default (usually 5).
+
+                                   **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_POOL_TIMEOUT``        Specifies the connection timeout in seconds
                                    for the pool.
+
+                                   **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_POOL_RECYCLE``        Number of seconds after which a
                                    connection is automatically recycled.
                                    This is required for MySQL, which removes
@@ -53,11 +59,15 @@ A list of configuration keys currently understood by the extension:
                                    different default timeout value. For more
                                    information about timeouts see
                                    :ref:`timeouts`.
+
+                                   **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_MAX_OVERFLOW``        Controls the number of connections that
                                    can be created after the pool reached
                                    its maximum size.  When those additional
                                    connections are returned to the pool,
                                    they are disconnected and discarded.
+
+                                   **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_TRACK_MODIFICATIONS`` If set to ``True``, Flask-SQLAlchemy will
                                    track modifications of objects and emit
                                    signals.  The default is ``None``, which
@@ -88,7 +98,16 @@ A list of configuration keys currently understood by the extension:
    ``SQLALCHEMY_TRACK_MODIFICATIONS`` will warn if unset.
 
 .. versionchanged:: 2.4
-   ``SQLALCHEMY_ENGINE_OPTIONS`` configuration key was added.
+
+* ``SQLALCHEMY_ENGINE_OPTIONS`` configuration key was added.
+* Deprecated keys
+
+  * ``SQLALCHEMY_NATIVE_UNICODE``
+  * ``SQLALCHEMY_POOL_SIZE``
+  * ``SQLALCHEMY_POOL_TIMEOUT``
+  * ``SQLALCHEMY_POOL_RECYCLE``
+  * ``SQLALCHEMY_MAX_OVERFLOW``
+
 
 Connection URI Format
 ---------------------

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -157,7 +157,14 @@ class SignallingSession(SessionBase):
     def get_bind(self, mapper=None, clause=None):
         # mapper is None if someone tries to just get a connection
         if mapper is not None:
-            info = getattr(mapper.mapped_table, 'info', {})
+            try:
+                # SA >= 1.3
+                persist_selectable = mapper.persist_selectable
+            except AttributeError:
+                # SA < 1.3
+                persist_selectable = mapper.mapped_table
+
+            info = getattr(persist_selectable, 'info', {})
             bind_key = info.get('bind_key')
             if bind_key is not None:
                 state = get_state(self.app)

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -567,7 +567,8 @@ class _EngineConnector(object):
             return rv
 
     def get_options(self, sa_url, echo):
-        options = {'convert_unicode': True}
+        options = {}
+
         self._sa.apply_pool_defaults(self._app, options)
         self._sa.apply_driver_hacks(self._app, sa_url, options)
         if echo:

--- a/flask_sqlalchemy/utils.py
+++ b/flask_sqlalchemy/utils.py
@@ -1,0 +1,20 @@
+
+from pkg_resources import parse_version
+import sqlalchemy
+
+
+def sqlalchemy_version(op, val):
+    sa_ver = parse_version(sqlalchemy.__version__)
+    target_ver = parse_version(val)
+
+    assert op in ('<', '>', '<=', '>=', '=='), 'op {} not supported'.format(op)
+
+    if op == '<':
+        return sa_ver < target_ver
+    if op == '>':
+        return sa_ver > target_ver
+    if op == '<=':
+        return sa_ver <= target_ver
+    if op == '>=':
+        return sa_ver >= target_ver
+    return sa_ver == target_ver

--- a/flask_sqlalchemy/utils.py
+++ b/flask_sqlalchemy/utils.py
@@ -1,6 +1,20 @@
 
-from pkg_resources import parse_version
 import sqlalchemy
+
+
+def parse_version(v):
+    """
+        Take a string version and conver it to a tuple (for easier comparison), e.g.:
+
+            "1.2.3" --> (1, 2, 3)
+            "1.2" --> (1, 2, 0)
+            "1" --> (1, 0, 0)
+    """
+    parts = v.split(".")
+    # Pad the list to make sure there is three elements so that we get major, minor, point
+    # comparisons that default to "0" if not given.  I.e. "1.2" --> (1, 2, 0)
+    parts = (parts + 3 * ['0'])[:3]
+    return tuple(int(x) for x in parts)
 
 
 def sqlalchemy_version(op, val):

--- a/flask_sqlalchemy/utils.py
+++ b/flask_sqlalchemy/utils.py
@@ -1,3 +1,4 @@
+import warnings
 
 import sqlalchemy
 
@@ -32,3 +33,13 @@ def sqlalchemy_version(op, val):
     if op == '>=':
         return sa_ver >= target_ver
     return sa_ver == target_ver
+
+
+def engine_config_warning(config, version, deprecated_config_key, engine_option):
+    if config[deprecated_config_key] is not None:
+        warnings.warn(
+            'The `{}` config option is deprecated and will be removed in'
+            ' v{}.  Use `SQLALCHEMY_ENGINE_OPTIONS[\'{}\']` instead.'
+            .format(deprecated_config_key, version, engine_option),
+            DeprecationWarning
+        )

--- a/tests/test_basic_app.py
+++ b/tests/test_basic_app.py
@@ -49,3 +49,13 @@ def test_query_recording(app, db, Todo):
 
 def test_helper_api(db):
     assert db.metadata == db.Model.metadata
+
+
+def test_persist_selectable(app, db, Todo, recwarn):
+    """ In SA 1.3, mapper.mapped_table should be replaced with mapper.persist_selectable """
+    with app.test_request_context():
+        todo = Todo('Test 1', 'test')
+        db.session.add(todo)
+        db.session.commit()
+
+    assert len(recwarn) == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import pytest
 from sqlalchemy.pool import NullPool
 
 import flask_sqlalchemy as fsa
+from flask_sqlalchemy import _compat, utils
 
 
 class TestConfigKeys:
@@ -71,7 +72,14 @@ class TestConfigKeys:
             errors or warnings.
         """
         assert fsa.SQLAlchemy(app).get_engine()
-        assert len(recwarn) == 0
+        if utils.sqlalchemy_version('==', '0.8.0') and not _compat.PY2:
+            # In CI, we test Python 3.6 and SA 0.8.0, which produces a warning for
+            # inspect.getargspec()
+            expected_warnings = 1
+        else:
+            expected_warnings = 0
+
+        assert len(recwarn) == expected_warnings
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,116 @@
+import flask_sqlalchemy as fsa
+
+import mock
+import pytest
+
+
+class TestConfigKeys:
+
+    def test_defaults(self, app):
+        """
+        Test all documented config values in the order they appear in our
+        documentation: http://flask-sqlalchemy.pocoo.org/dev/config/
+        """
+        # Our pytest fixture for creating the app sets
+        # SQLALCHEMY_TRACK_MODIFICATIONS, so we undo that here so that we
+        # can inspect what FSA does below:
+        del app.config['SQLALCHEMY_TRACK_MODIFICATIONS']
+
+        with pytest.warns(fsa.FSADeprecationWarning) as records:
+            fsa.SQLAlchemy(app)
+
+        # Only expecting one warning for the track modifications deprecation.
+        assert len(records) == 1
+
+        assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:///:memory:'
+        assert app.config['SQLALCHEMY_BINDS'] is None
+        assert app.config['SQLALCHEMY_ECHO'] is False
+        assert app.config['SQLALCHEMY_RECORD_QUERIES'] is None
+        assert app.config['SQLALCHEMY_NATIVE_UNICODE'] is None
+        assert app.config['SQLALCHEMY_POOL_SIZE'] is None
+        assert app.config['SQLALCHEMY_POOL_TIMEOUT'] is None
+        assert app.config['SQLALCHEMY_POOL_RECYCLE'] is None
+        assert app.config['SQLALCHEMY_MAX_OVERFLOW'] is None
+        assert app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] is None
+        assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {}
+
+    def test_track_modifications_warning(self, app, recwarn):
+
+        # pytest fixuture sets SQLALCHEMY_TRACK_MODIFICATIONS = False
+        fsa.SQLAlchemy(app)
+
+        # So we shouldn't have any warnings
+        assert len(recwarn) == 0
+
+        # Let's trigger the warning
+        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = None
+        fsa.SQLAlchemy(app)
+
+        # and verify it showed up as expected
+        assert len(recwarn) == 1
+        expect = 'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead' \
+                 ' and will be disabled by default in the future.  Set it' \
+                 ' to True or False to suppress this warning.'
+        assert recwarn[0].message.args[0] == expect
+
+    def test_uri_binds_warning(self, app, recwarn):
+        # Let's trigger the warning
+        del app.config['SQLALCHEMY_DATABASE_URI']
+        fsa.SQLAlchemy(app)
+
+        # and verify it showed up as expected
+        assert len(recwarn) == 1
+        expect = 'Neither SQLALCHEMY_DATABASE_URI nor SQLALCHEMY_BINDS' \
+                 ' is set. Defaulting SQLALCHEMY_DATABASE_URI to'\
+                 ' "sqlite:///:memory:".'
+        assert recwarn[0].message.args[0] == expect
+
+
+@pytest.fixture
+def app_nr(app):
+    """
+        Signal/event registration with record queries breaks when
+        sqlalchemy.create_engine() is mocked out.
+    """
+    app.config['SQLALCHEMY_RECORD_QUERIES'] = False
+    return app
+
+
+@mock.patch.object(fsa.sqlalchemy, 'create_engine', autospec=True, spec_set=True)
+class TestCreateEngine:
+    """
+        Tests for _EngineConnector and SQLAlchemy methods inolved in setting up
+        the SQLAlchemy engine.
+    """
+
+    def test_engine_echo_default(self, m_create_engine, app_nr):
+        fsa.SQLAlchemy(app_nr).get_engine()
+
+        args, options = m_create_engine.call_args
+        assert 'echo' not in options
+
+    def test_engine_echo_true(self, m_create_engine, app_nr):
+        app_nr.config['SQLALCHEMY_ECHO'] = True
+        fsa.SQLAlchemy(app_nr).get_engine()
+
+        args, options = m_create_engine.call_args
+        assert options['echo'] is True
+
+    def test_convert_unicode_default(self, m_create_engine, app_nr):
+        fsa.SQLAlchemy(app_nr).get_engine()
+
+        args, options = m_create_engine.call_args
+        assert options['convert_unicode'] is True
+
+    def test_config_from_engine_options(self, m_create_engine, app_nr):
+        app_nr.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'foo': 'bar'}
+        fsa.SQLAlchemy(app_nr).get_engine()
+
+        args, options = m_create_engine.call_args
+        assert options['foo'] == 'bar'
+
+    def test_config_from_init(self, m_create_engine, app_nr):
+        fsa.SQLAlchemy(app_nr, engine_options={'bar': 'baz'}).get_engine()
+
+        args, options = m_create_engine.call_args
+        assert options['bar'] == 'baz'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,11 +66,12 @@ class TestConfigKeys:
                  ' "sqlite:///:memory:".'
         assert recwarn[0].message.args[0] == expect
 
-    def test_engine_creation_ok(self, app):
+    def test_engine_creation_ok(self, app, recwarn):
         """ create_engine() isn't called until needed.  Let's make sure we can do that without
-            errors.
+            errors or warnings.
         """
         assert fsa.SQLAlchemy(app).get_engine()
+        assert len(recwarn) == 0
 
 
 @pytest.fixture
@@ -103,11 +104,13 @@ class TestCreateEngine:
         args, options = m_create_engine.call_args
         assert options['echo'] is True
 
-    def test_convert_unicode_default(self, m_create_engine, app_nr):
+    @mock.patch.object(fsa.utils, 'sqlalchemy')
+    def test_convert_unicode_default_sa_13(self, m_sqlalchemy, m_create_engine, app_nr):
+        m_sqlalchemy.__version__ = '1.3'
         fsa.SQLAlchemy(app_nr).get_engine()
 
         args, options = m_create_engine.call_args
-        assert options['convert_unicode'] is True
+        assert 'convert_unicode' not in options
 
     def test_config_from_engine_options(self, m_create_engine, app_nr):
         app_nr.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'foo': 'bar'}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import mock
+
+from flask_sqlalchemy import utils
+
+
+class TestSQLAlchemyVersion:
+
+    @mock.patch.object(utils, 'sqlalchemy')
+    def test_sqlalchemy_version(self, m_sqlalchemy):
+        m_sqlalchemy.__version__ = '1.3'
+
+        assert not utils.sqlalchemy_version('<', '1.3')
+        assert not utils.sqlalchemy_version('>', '1.3')
+        assert utils.sqlalchemy_version('<=', '1.3')
+        assert utils.sqlalchemy_version('==', '1.3')
+        assert utils.sqlalchemy_version('>=', '1.3')
+
+        m_sqlalchemy.__version__ = '1.2.99'
+
+        assert utils.sqlalchemy_version('<', '1.3')
+        assert not utils.sqlalchemy_version('>', '1.3')
+        assert utils.sqlalchemy_version('<=', '1.3')
+        assert not utils.sqlalchemy_version('==', '1.3')
+        assert not utils.sqlalchemy_version('>=', '1.3')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,10 @@ from flask_sqlalchemy import utils
 
 
 class TestSQLAlchemyVersion:
+    def test_parse_version(self):
+        assert utils.parse_version('1.2.3') == (1, 2, 3)
+        assert utils.parse_version('1.2') == (1, 2, 0)
+        assert utils.parse_version('1') == (1, 0, 0)
 
     @mock.patch.object(utils, 'sqlalchemy')
     def test_sqlalchemy_version(self, m_sqlalchemy):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pytest>=3
     coverage
     blinker
+    mock
 
     py27-lowest,py36-lowest: flask==0.12
     py27-lowest,py36-lowest: sqlalchemy==0.8


### PR DESCRIPTION
fixes #166 - make it possible to pass additional options to create_engine()
fixes #671, #681 - deprecation warnings from SA 1.3