### PR TITLE
fix DeprecationWarning: time.clock

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -36,7 +36,7 @@ __version__ = '2.3.2'
 
 # the best timer function for the platform
 if sys.platform == 'win32':
-    _timer = time.clock
+    _timer = time.perf_counter
 else:
     _timer = time.time
 


### PR DESCRIPTION
fix `DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead`

`time.clock` has been replaced with `time.perf_counter` in the code.