### PR TITLE
Allow to pass args to pytest through tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     lowest: sqlalchemy==0.8
 
 commands =
-    coverage run -p -m pytest
+    coverage run -p -m pytest {posargs}
 
 [testenv:docs_html]
 deps = sphinx


### PR DESCRIPTION
example:
```
tox -e py35 -- --sw
```