### PR TITLE
Remove convert_unicode option, as it is being depreciated

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -555,7 +555,7 @@ class _EngineConnector(object):
             if (uri, echo) == self._connected_for:
                 return self._engine
             info = make_url(uri)
-            options = {'convert_unicode': True}
+            options = {}
             self._sa.apply_pool_defaults(self._app, options)
             self._sa.apply_driver_hacks(self._app, info, options)
             if echo:


### PR DESCRIPTION
Hi,
I am getting the following error continually:

`/home/robin/.local/share/virtualenvs/gridt-server-ZYPDaXQg/lib/python3.7/site-packages/sqlalchemy/dialects/sqlite/base.py:1433: SADeprecationWarning: The create_e
ngine.convert_unicode parameter and corresponding dialect-level parameters are deprecated, and will be removed in a future release.  Modern DBAPIs support Python
Unicode natively and this parameter is unnecessary.
`
This should be the cause of that.