### PR TITLE
Fix tox spec

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     coverage
     blinker
 
-    py27,py36-lowest: flask==0.12
-    py27,py36-lowest: sqlalchemy==0.8
+    py27-lowest,py36-lowest: flask==0.12
+    py27-lowest,py36-lowest: sqlalchemy==0.8
     # This is the first version that works w/ Python 3.7
     py37-lowest: sqlalchemy==1.0.10
 


### PR DESCRIPTION
When running with just `tox` you'd get the "lowest" library versions for the plain py27 run.