### PR TITLE
Add Contributing docs, add donate section to README

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,10 @@
-**This issue tracker is a tool to address bugs and feature requests in
-Flask-SQLAlchemy itself. Please use the [#pocoo IRC channel on freenode](http://flask.pocoo.org/community/irc/)
-or [Stack Overflow](https://stackoverflow.com/questions/tagged/flask-sqlalchemy?sort=linked) for general questions about using Flask-SQLAlchemy
-or issues not related to Flask-SQLAlchemy.**
+Read and remove this section before submitting your issue. Also read
+CONTRIBUTING.rst for detailed instructions.
 
-If you'd like to report a issue in Flask-SQLAlchemy, fill out the template below.
-Provide any extra information that may be useful / related to your problem.
-Ideally, create a [minimal, complete, and verifiable example (MCVE)](https://stackoverflow.com/help/mcve),
-which helps us understand the problem and helps check that it is not caused
-by something in your code.
-
-Flask-SQLAlchemy is a thin wrapper that combines [Flask](https://github.com/pallets/flask) and [SQLAlchemy](https://github.com/sqlalchemy/sqlalchemy). Please
-make sure your issue is **actually with Flask-SQLAlchemy and not SQLAlchemy** before
-submitting. Consider checking the traceback to see if the error is coming from SQLAlchemy,
-or checking if your issue has already been reported as a [SQLAlchemy issue on GitHub](https://github.com/sqlalchemy/sqlalchemy/issues).
-
-Also, please be kind - this project is maintained by volunteers. We appreciate
-you taking the time to provide the information needed to address your issue.
+This issue tracker is a tool to address bugs and feature requests in
+Flask-SQLAlchemy itself. Use Discord or Stack Overflow for questions
+about using Flask-SQLAlchemy or issues with your own code. Ensure your
+issue is with Flask-SQLAlchemy and not SQLAlchemy itself.
 
 ---
 
@@ -37,7 +26,6 @@ Paste the full traceback if there was an exception.
 
 ### Environment
 
-* Operating system:
 * Python version:
 * Flask-SQLAlchemy version:
 * SQLAlchemy version:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,151 +3,219 @@ How to contribute to Flask-SQLAlchemy
 
 Thank you for considering contributing to Flask-SQLAlchemy!
 
+
 Support questions
 -----------------
 
-Please, don't use the issue tracker for this. Use one of the following
-resources for questions about your own code:
+Please, don't use the issue tracker for this. The issue tracker is a
+tool to address bugs and feature requests in Flask-SQLAlchemy itself.
+Use one of the following resources for questions about using
+Flask-SQLAlchemy or issues with your own code:
 
-* The IRC channel ``#pocoo`` on FreeNode.
-* The IRC channel ``#python`` on FreeNode for more general questions.
-* The mailing list flask@python.org for long term discussion or larger issues.
-* Ask on `Stack Overflow`_. Search with Google first using:
-  ``site:stackoverflow.com flask-sqlalchemy {search term, exception message, etc.}``
+-   The ``#get-help`` channel on our Discord chat:
+    https://discord.gg/t6rrQZH
+-   The mailing list flask@python.org for long term discussion or larger
+    issues.
+-   Ask on `Stack Overflow`_. Search with Google first using:
+    ``site:stackoverflow.com flask sqlalchemy {search term, exception message, etc.}``
 
 .. _Stack Overflow: https://stackoverflow.com/questions/tagged/flask-sqlalchemy?sort=linked
+
 
 Reporting issues
 ----------------
 
-- Describe what you expected to happen.
-- If possible, include a `minimal, complete, and verifiable example`_ to help
-  us identify the issue. This also helps check that the issue is not with your
-  own code.
-- Describe what actually happened. Include the full traceback if there was an
-  exception.
-- List your Python, Flask, and Werkzeug versions. If possible, check if this
-  issue is already fixed in the repository.
+Flask-SQLAlchemy is a thin wrapper that combines Flask and SQLAlchemy.
+Make sure your issue is actually with Flask-SQLAlchemy and not
+SQLAlchemy before submitting it. Check the traceback to see if the error
+is coming from SQLAlchemy. Check if your issue has already been reported
+to `SQLAlchemy`_.
 
-.. _minimal, complete, and verifiable example: https://stackoverflow.com/help/mcve
+Include the following information in your post:
+
+-   Describe what you expected to happen.
+-   If possible, include a `minimal reproducible example`_ to help us
+    identify the issue. This also helps check that the issue is not with
+    your own code.
+-   Describe what actually happened. Include the full traceback if there
+    was an exception.
+-   List your Python, Flask-SQLAlchemy, and SQLAlchemy versions. If
+    possible, check if this issue is already fixed in the latest
+    releases or the latest code in the repository.
+
+.. _SQLAlchemy: https://github.com/sqlalchemy/sqlalchemy/issues
+.. _minimal reproducible example: https://stackoverflow.com/help/minimal-reproducible-example
+
 
 Submitting patches
 ------------------
 
-- Include tests if your patch is supposed to solve a bug, and explain
-  clearly under which circumstances the bug happens. Make sure the test fails
-  without your patch.
-- Try to follow `PEP8`_, but you may ignore the line length limit if following
-  it would make the code uglier.
+If there is not an open issue for what you want to submit, prefer
+opening one for discussion before working on a PR. You can work on any
+issue that doesn't have an open PR linked to it or a maintainer assigned
+to it. These show up in the sidebar. No need to ask if you can work on
+an issue that interests you.
+
+Include the following in your patch:
+
+-   Use `Black`_ to format your code. This and other checks will run
+    automatically if you install `pre-commit`_ using the instructions
+    below.
+-   Include tests if your patch adds or changes code. Make sure the test
+    fails without your patch.
+-   Update any relevant docs pages and docstrings. Docs pages and
+    docstrings should be wrapped at 72 characters.
+-   Add an entry in ``CHANGES.rst``. Use the same style as other
+    entries. Also include ``.. versionchanged::`` inline changelogs in
+    relevant docstrings.
+
+.. _Black: https://black.readthedocs.io
+.. _pre-commit: https://pre-commit.com
+
 
 First time setup
 ~~~~~~~~~~~~~~~~
 
-- Download and install the `latest version of git`_.
-- Configure git with your `username`_ and `email`_::
+-   Download and install the `latest version of git`_.
+-   Configure git with your `username`_ and `email`_.
 
-        git config --global user.name 'your name'
-        git config --global user.email 'your email'
+    .. code-block:: text
 
-- Make sure you have a `GitHub account`_.
-- Fork Flask-SQLAlchemy to your GitHub account by clicking the `Fork`_ button.
-- `Clone`_ your GitHub fork locally::
+        $ git config --global user.name 'your name'
+        $ git config --global user.email 'your email'
 
-        git clone https://github.com/{username}/flask-sqlalchemy
-        cd flask-sqlalchemy
+-   Make sure you have a `GitHub account`_.
+-   Fork Flask-SQLAlchemy to your GitHub account by clicking the `Fork`_
+    button.
+-   `Clone`_ the main repository locally.
 
-- Add the main repository as a remote to update later::
+    .. code-block:: text
 
-        git remote add pallets https://github.com/pallets/flask-sqlalchemy
-        git fetch pallets
+        $ git clone https://github.com/pallets/flask-sqlalchemy
+        $ cd flask-sqlalchemy
 
-- Create a virtualenv::
+-   Add your fork as a remote to push your work to. Replace
+    ``{username}`` with your username.
 
-        python3 -m venv env
-        . env/bin/activate
-        # or "env\Scripts\activate" on Windows
+    .. code-block:: text
 
-- Install Flask-SQLAlchemy in editable mode with development dependencies::
+        git remote add fork https://github.com/{username}/flask-sqlalchemy
 
-        pip install -e .
+-   Create a virtualenv.
 
-.. _GitHub account: https://github.com/join
+    .. code-block:: text
+
+        $ python3 -m venv env
+        $ . env/bin/activate
+
+    On Windows, activating is different.
+
+    .. code-block:: text
+
+        > env\Scripts\activate
+
+-   Install Flask-SQLAlchemy in editable mode with development
+    dependencies.
+
+    .. code-block:: text
+
+        $ pip install -e . -r requirements/dev.txt
+
+-   Install the pre-commit hooks.
+
+    .. code-block:: text
+
+        $ pre-commit install
+
 .. _latest version of git: https://git-scm.com/downloads
-.. _username: https://help.github.com/articles/setting-your-username-in-git/
-.. _email: https://help.github.com/articles/setting-your-email-in-git/
-.. _Fork: https://github.com/pallets/flask-sqlalchemy/fork
-.. _Clone: https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork
+.. _username: https://help.github.com/en/articles/setting-your-username-in-git
+.. _email: https://help.github.com/en/articles/setting-your-commit-email-address-in-git
+.. _GitHub account: https://github.com/join
+.. _Fork: https://github.com/pallets/flask/fork
+.. _Clone: https://help.github.com/en/articles/fork-a-repo#step-2-create-a-local-clone-of-your-fork
+
 
 Start coding
 ~~~~~~~~~~~~
 
-- Create a branch to identify the issue you would like to work on (e.g.
-  ``2287-dry-test-suite``)
-- Using your favorite editor, make your changes, `committing as you go`_.
-- Try to follow `PEP8`_, but you may ignore the line length limit if following
-  it would make the code uglier.
-- Include tests that cover any code changes you make. Make sure the test fails
-  without your patch. `Run the tests. <contributing-testsuite_>`_.
-- Push your commits to GitHub and `create a pull request`_.
-- Celebrate 🎉
+-   Create a branch to identify the issue you would like to work on. If
+    you're submitting a bug or documentation fix, branch off of the
+    latest ".x" branch.
+
+    .. code-block:: text
+
+        $ git checkout -b your-branch-name origin/2.x
+
+    If you're submitting a feature addition or change, branch off of the
+    "master" branch.
+
+    .. code-block:: text
+
+        $ git checkout -b your-branch-name origin/master
+
+-   Using your favorite editor, make your changes,
+    `committing as you go`_.
+-   Include tests that cover any code changes you make. Make sure the
+    test fails without your patch. Run the tests as described below.
+-   Push your commits to your fork on GitHub and
+    `create a pull request`_. Link to the issue being addressed with
+    ``fixes #123`` in the pull request.
+
+    .. code-block:: text
+
+        $ git push --set-upstream fork your-branch-name
 
 .. _committing as you go: https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
-.. _PEP8: https://pep8.org/
-.. _create a pull request: https://help.github.com/articles/creating-a-pull-request/
+.. _create a pull request: https://help.github.com/en/articles/creating-a-pull-request
 
-.. _contributing-testsuite:
 
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
-Install the testing requirements::
+Run the basic test suite with pytest.
 
-    pip install pytest mock tox coverage
+.. code-block:: text
 
-Run the basic test suite from the project directory with::
+    $ pytest
 
-    pytest
+This runs the tests for the current environment, which is usually
+sufficient. CI will run the full suite when you submit your pull
+request. You can run the full test suite with tox if you don't want to
+wait.
 
-This only runs the tests for the current environment. Whether this is relevant
-depends on which part of Flask-SQLAlchemy you're working on. Travis-CI will run
-the full suite when you submit your pull request.
+.. code-block:: text
 
-The full test suite takes a long time to run because it tests multiple
-combinations of Python and dependencies. You need to have Python 2.7, 3.4,
-3.5 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
+    $ tox
 
-    tox
 
 Running test coverage
 ~~~~~~~~~~~~~~~~~~~~~
 
 Generating a report of lines that do not have test coverage can indicate
-where to start contributing. Run ``pytest`` using ``coverage`` and generate a
-report on the terminal and as an interactive HTML document::
+where to start contributing. Run ``pytest`` using ``coverage`` and
+generate a report.
 
-    coverage run -m pytest
-    coverage report
-    coverage html
-    # then open htmlcov/index.html
+.. code-block:: text
 
-Read more about `coverage <https://coverage.readthedocs.io>`_.
+    $ pip install coverage
+    $ coverage run -m pytest
+    $ coverage html
 
-Running the full test suite with ``tox`` will combine the coverage reports
-from all runs.
+Open ``htmlcov/index.html`` in your browser to explore the report.
+
+Read more about `coverage <https://coverage.readthedocs.io>`__.
 
 
 Building the docs
 ~~~~~~~~~~~~~~~~~
 
-Install the ``docs ``requirements::
+Build the docs in the ``docs`` directory using Sphinx.
 
-    cd docs
-    pip install -r requirements.txt
+.. code-block:: text
 
-Build the docs using ``sphinx``::
-
-    make html
+    $ cd docs
+    $ make html
 
 Open ``_build/html/index.html`` in your browser to view the docs.
 
-Read more about `Sphinx <https://www.sphinx-doc.org>`_.
+Read more about `Sphinx <https://www.sphinx-doc.org/en/stable/>`__.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,153 @@
+How to contribute to Flask-SQLAlchemy
+=====================================
+
+Thank you for considering contributing to Flask-SQLAlchemy!
+
+Support questions
+-----------------
+
+Please, don't use the issue tracker for this. Use one of the following
+resources for questions about your own code:
+
+* The IRC channel ``#pocoo`` on FreeNode.
+* The IRC channel ``#python`` on FreeNode for more general questions.
+* The mailing list flask@python.org for long term discussion or larger issues.
+* Ask on `Stack Overflow`_. Search with Google first using:
+  ``site:stackoverflow.com flask-sqlalchemy {search term, exception message, etc.}``
+
+.. _Stack Overflow: https://stackoverflow.com/questions/tagged/flask-sqlalchemy?sort=linked
+
+Reporting issues
+----------------
+
+- Describe what you expected to happen.
+- If possible, include a `minimal, complete, and verifiable example`_ to help
+  us identify the issue. This also helps check that the issue is not with your
+  own code.
+- Describe what actually happened. Include the full traceback if there was an
+  exception.
+- List your Python, Flask, and Werkzeug versions. If possible, check if this
+  issue is already fixed in the repository.
+
+.. _minimal, complete, and verifiable example: https://stackoverflow.com/help/mcve
+
+Submitting patches
+------------------
+
+- Include tests if your patch is supposed to solve a bug, and explain
+  clearly under which circumstances the bug happens. Make sure the test fails
+  without your patch.
+- Try to follow `PEP8`_, but you may ignore the line length limit if following
+  it would make the code uglier.
+
+First time setup
+~~~~~~~~~~~~~~~~
+
+- Download and install the `latest version of git`_.
+- Configure git with your `username`_ and `email`_::
+
+        git config --global user.name 'your name'
+        git config --global user.email 'your email'
+
+- Make sure you have a `GitHub account`_.
+- Fork Flask-SQLAlchemy to your GitHub account by clicking the `Fork`_ button.
+- `Clone`_ your GitHub fork locally::
+
+        git clone https://github.com/{username}/flask-sqlalchemy
+        cd flask-sqlalchemy
+
+- Add the main repository as a remote to update later::
+
+        git remote add pallets https://github.com/pallets/flask-sqlalchemy
+        git fetch pallets
+
+- Create a virtualenv::
+
+        python3 -m venv env
+        . env/bin/activate
+        # or "env\Scripts\activate" on Windows
+
+- Install Flask-SQLAlchemy in editable mode with development dependencies::
+
+        pip install -e .
+
+.. _GitHub account: https://github.com/join
+.. _latest version of git: https://git-scm.com/downloads
+.. _username: https://help.github.com/articles/setting-your-username-in-git/
+.. _email: https://help.github.com/articles/setting-your-email-in-git/
+.. _Fork: https://github.com/pallets/flask-sqlalchemy/fork
+.. _Clone: https://help.github.com/articles/fork-a-repo/#step-2-create-a-local-clone-of-your-fork
+
+Start coding
+~~~~~~~~~~~~
+
+- Create a branch to identify the issue you would like to work on (e.g.
+  ``2287-dry-test-suite``)
+- Using your favorite editor, make your changes, `committing as you go`_.
+- Try to follow `PEP8`_, but you may ignore the line length limit if following
+  it would make the code uglier.
+- Include tests that cover any code changes you make. Make sure the test fails
+  without your patch. `Run the tests. <contributing-testsuite_>`_.
+- Push your commits to GitHub and `create a pull request`_.
+- Celebrate 🎉
+
+.. _committing as you go: https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html#commit-your-changes
+.. _PEP8: https://pep8.org/
+.. _create a pull request: https://help.github.com/articles/creating-a-pull-request/
+
+.. _contributing-testsuite:
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+Install the testing requirements::
+
+    pip install pytest mock tox coverage
+
+Run the basic test suite from the project directory with::
+
+    pytest
+
+This only runs the tests for the current environment. Whether this is relevant
+depends on which part of Flask-SQLAlchemy you're working on. Travis-CI will run
+the full suite when you submit your pull request.
+
+The full test suite takes a long time to run because it tests multiple
+combinations of Python and dependencies. You need to have Python 2.7, 3.4,
+3.5 3.6, and PyPy 2.7 installed to run all of the environments. Then run::
+
+    tox
+
+Running test coverage
+~~~~~~~~~~~~~~~~~~~~~
+
+Generating a report of lines that do not have test coverage can indicate
+where to start contributing. Run ``pytest`` using ``coverage`` and generate a
+report on the terminal and as an interactive HTML document::
+
+    coverage run -m pytest
+    coverage report
+    coverage html
+    # then open htmlcov/index.html
+
+Read more about `coverage <https://coverage.readthedocs.io>`_.
+
+Running the full test suite with ``tox`` will combine the coverage reports
+from all runs.
+
+
+Building the docs
+~~~~~~~~~~~~~~~~~
+
+Install the ``docs ``requirements::
+
+    cd docs
+    pip install -r requirements.txt
+
+Build the docs using ``sphinx``::
+
+    make html
+
+Open ``_build/html/index.html`` in your browser to view the docs.
+
+Read more about `Sphinx <https://www.sphinx-doc.org>`_.

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ Flask-SQLAlchemy is an extension for `Flask`_ that adds support for
 with Flask by providing useful defaults and extra helpers that make it
 easier to accomplish common tasks.
 
+.. _Flask: https://palletsprojects.com/p/flask/
+.. _SQLAlchemy: https://www.sqlalchemy.org
+
 
 Installing
 ----------
@@ -15,6 +18,8 @@ Install and update using `pip`_:
 .. code-block:: text
 
   $ pip install -U Flask-SQLAlchemy
+
+.. _pip: https://pip.pypa.io/en/stable/quickstart/
 
 
 A Simple Example
@@ -54,11 +59,11 @@ contribution to Flask-SQLAlchemy, see the `contributing guidelines`_.
 Donate
 ------
 
-The Pallets organization develops and supports Flask-SQLAlchemy.
-In order to grow the community of contributors and users, and allow
-the maintainers to devote more time to the projects, `please donate today`_.
+The Pallets organization develops and supports Flask-SQLAlchemy. In
+order to grow the community of contributors and users, and allow the
+maintainers to devote more time to the projects, `please donate today`_.
 
-.. _please donate today: https://psfmember.org/civicrm/contribute/transact?reset=1&id=20
+.. _please donate today: https://palletsprojects.com/donate
 
 
 Links
@@ -68,7 +73,4 @@ Links
 -   Releases: https://pypi.org/project/Flask-SQLAlchemy/
 -   Code: https://github.com/pallets/flask-sqlalchemy
 -   Issue tracker: https://github.com/pallets/flask-sqlalchemy/issues
-
-.. _Flask: https://palletsprojects.com/p/flask/
-.. _SQLAlchemy: https://www.sqlalchemy.org
-.. _pip: https://pip.pypa.io/en/stable/quickstart/
+-   Official chat: https://discord.gg/t6rrQZH

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,25 @@ A Simple Example
     users = User.query.all()
 
 
+Contributing
+------------
+
+For guidance on setting up a development environment and how to make a
+contribution to Flask-SQLAlchemy, see the `contributing guidelines`_.
+
+.. _contributing guidelines: https://github.com/pallets/flask-sqlalchemy/blob/master/CONTRIBUTING.rst
+
+
+Donate
+------
+
+The Pallets organization develops and supports Flask-SQLAlchemy.
+In order to grow the community of contributors and users, and allow
+the maintainers to devote more time to the projects, `please donate today`_.
+
+.. _please donate today: https://psfmember.org/civicrm/contribute/transact?reset=1&id=20
+
+
 Links
 -----
 


### PR DESCRIPTION
Resolves #723:
- Adds **Contributing** doc, links to it in the README
- Updates README to have a donate section to match Flask and other Pallets projects

Notes:
- The contributing document is based on [Flask's contributing document](https://github.com/pallets/flask/blob/master/CONTRIBUTING.rst)
- The contributing document is slightly different for testing and documentation instructions
