### PR TITLE
Set SQLALCHEMY_TRACK_MODIFICATIONS to False by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 3.0.0
 
 Unreleased
 
+-   Set `SQLALCHEMY_TRACK_MODIFICATIONS` to `False` by default,
+    remove deprecation warning (:pr:`727`)
+
 
 Version 2.4.0
 -------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -70,10 +70,8 @@ A list of configuration keys currently understood by the extension:
                                    **Deprecated** as of v2.4 and will be removed in v3.0.
 ``SQLALCHEMY_TRACK_MODIFICATIONS`` If set to ``True``, Flask-SQLAlchemy will
                                    track modifications of objects and emit
-                                   signals.  The default is ``None``, which
-                                   enables tracking but issues a warning
-                                   that it will be disabled by default in
-                                   the future.  This requires extra memory
+                                   signals.  The default is ``False`` because
+                                   this requires extra memory
                                    and should be disabled if not needed.
 ``SQLALCHEMY_ENGINE_OPTIONS``      A dictionary of keyword args to send to
                                    :func:`~sqlalchemy.create_engine`.  See

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -138,7 +138,7 @@ class SignallingSession(SessionBase):
         bind = options.pop('bind', None) or db.engine
         binds = options.pop('binds', db.get_binds(app))
 
-        if track_modifications is None or track_modifications:
+        if track_modifications:
             _SessionSignalEvents.register(self)
 
         SessionBase.__init__(
@@ -829,17 +829,8 @@ class SQLAlchemy(object):
         app.config.setdefault('SQLALCHEMY_POOL_RECYCLE', None)
         app.config.setdefault('SQLALCHEMY_MAX_OVERFLOW', None)
         app.config.setdefault('SQLALCHEMY_COMMIT_ON_TEARDOWN', False)
-        track_modifications = app.config.setdefault(
-            'SQLALCHEMY_TRACK_MODIFICATIONS', None
-        )
+        app.config.setdefault('SQLALCHEMY_TRACK_MODIFICATIONS', False)
         app.config.setdefault('SQLALCHEMY_ENGINE_OPTIONS', {})
-
-        if track_modifications is None:
-            warnings.warn(FSADeprecationWarning(
-                'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
-                'will be disabled by default in the future.  Set it to True '
-                'or False to suppress this warning.'
-            ))
 
         # Deprecation warnings for config keys that should be replaced by SQLALCHEMY_ENGINE_OPTIONS.
         utils.engine_config_warning(app.config, '3.0', 'SQLALCHEMY_POOL_SIZE', 'pool_size')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ def app(request):
     app = flask.Flask(request.module.__name__)
     app.testing = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     return app
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,21 +18,16 @@ def app_nr(app):
 
 class TestConfigKeys:
 
-    def test_defaults(self, app):
+    def test_defaults(self, app, recwarn):
         """
         Test all documented config values in the order they appear in our
         documentation: http://flask-sqlalchemy.pocoo.org/dev/config/
         """
-        # Our pytest fixture for creating the app sets
-        # SQLALCHEMY_TRACK_MODIFICATIONS, so we undo that here so that we
-        # can inspect what FSA does below:
-        del app.config['SQLALCHEMY_TRACK_MODIFICATIONS']
 
-        with pytest.warns(fsa.FSADeprecationWarning) as records:
-            fsa.SQLAlchemy(app)
+        fsa.SQLAlchemy(app)
 
-        # Only expecting one warning for the track modifications deprecation.
-        assert len(records) == 1
+        # Expecting no warnings for default config
+        assert len(recwarn) == 0
 
         assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:///:memory:'
         assert app.config['SQLALCHEMY_BINDS'] is None
@@ -43,27 +38,8 @@ class TestConfigKeys:
         assert app.config['SQLALCHEMY_POOL_TIMEOUT'] is None
         assert app.config['SQLALCHEMY_POOL_RECYCLE'] is None
         assert app.config['SQLALCHEMY_MAX_OVERFLOW'] is None
-        assert app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] is None
+        assert app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] is False
         assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {}
-
-    def test_track_modifications_warning(self, app, recwarn):
-
-        # pytest fixuture sets SQLALCHEMY_TRACK_MODIFICATIONS = False
-        fsa.SQLAlchemy(app)
-
-        # So we shouldn't have any warnings
-        assert len(recwarn) == 0
-
-        # Let's trigger the warning
-        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = None
-        fsa.SQLAlchemy(app)
-
-        # and verify it showed up as expected
-        assert len(recwarn) == 1
-        expect = 'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead' \
-                 ' and will be disabled by default in the future.  Set it' \
-                 ' to True or False to suppress this warning.'
-        assert recwarn[0].message.args[0] == expect
 
     def test_uri_binds_warning(self, app, recwarn):
         # Let's trigger the warning


### PR DESCRIPTION
Resolves #699 

- Set `SQLALCHEMY_TRACK_MODIFICATIONS` to `False` by default
- Update tests to reflect new behavior
- Update pytest configuration to no longer set `app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False`
- Update `docs` to reflect new default