### PR TITLE
Default SQLALCHEMY_DATABASE_URI to None, error if no URI or binds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,11 @@ Unreleased
 -   Drop support for Python 3.4.
 -   Bump minimum version of Flask to 1.0.4.
 -   Bump minimum version of SQLAlchemy to 1.2.
--   Set `SQLALCHEMY_TRACK_MODIFICATIONS` to `False` by default,
+-   Set ``SQLALCHEMY_TRACK_MODIFICATIONS`` to ``False`` by default,
     remove deprecation warning (:pr:`727`)
+-   Remove default ``'sqlite:///:memory:'`` setting for
+    ``SQLALCHEMY_DATABASE_URI``, raise error when both ``SQLALCHEMY_DATABASE_URI``
+    and ``SQLALCHEMY_BINDS`` are unset (:pr:`731`)
 
 
 Version 2.4.1

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -106,6 +106,10 @@ A list of configuration keys currently understood by the extension:
   * ``SQLALCHEMY_POOL_RECYCLE``
   * ``SQLALCHEMY_MAX_OVERFLOW``
 
+.. versionchanged:: 3.0
+
+  * ``SQLALCHEMY_TRACK_MODIFICATIONS`` configuration key now defaults to ``False``
+  * ``SQLALCHEMY_DATABASE_URI``  configuration key no longer defaults to ``'sqlite:///:memory:'``
 
 Connection URI Format
 ---------------------

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -810,19 +810,18 @@ class SQLAlchemy(object):
         of an application not initialized that way or connections will
         leak.
         """
+
         # We intentionally don't set self.app = app, to support multiple
         # applications. If the app is passed in the constructor,
         # we set it and don't support multiple applications.
-        if (
-            'SQLALCHEMY_DATABASE_URI' not in app.config and
-            'SQLALCHEMY_BINDS' not in app.config
+        if not (
+            app.config.get('SQLALCHEMY_DATABASE_URI')
+            or app.config.get('SQLALCHEMY_BINDS')
         ):
-            warnings.warn(
-                'Neither SQLALCHEMY_DATABASE_URI nor SQLALCHEMY_BINDS is set. '
-                'Defaulting SQLALCHEMY_DATABASE_URI to "sqlite:///:memory:".'
-            )
+            raise RuntimeError('Either SQLALCHEMY_DATABASE_URI '
+                               'or SQLALCHEMY_BINDS needs to be set.')
 
-        app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')
+        app.config.setdefault('SQLALCHEMY_DATABASE_URI', None)
         app.config.setdefault('SQLALCHEMY_BINDS', None)
         app.config.setdefault('SQLALCHEMY_NATIVE_UNICODE', None)
         app.config.setdefault('SQLALCHEMY_ECHO', False)


### PR DESCRIPTION
Resolves #663 

- Default `SQLALCHEMY_DATABASE_URI` to `None` and throw an error when `SQLALCHEMY_DATABASE_URI` and `SQLALCHEMY_BINDS` are unset
- Update tests (`test_defaults` is now split into `test_default_error_without_uri_or_binds` and `test_defaults_with_uri`)
- Update 3.x docs for this change as well as tweaking change for https://github.com/pallets/flask-sqlalchemy/pull/727
- Update changelog and reformat change for https://github.com/pallets/flask-sqlalchemy/pull/727
