### PR TITLE
Issue #482: Add as_dict method to Pagination object and associated tests

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import datetime as dt
 import functools
 import os
 import sys
@@ -21,7 +20,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 
 from flask_sqlalchemy.model import Model
-from ._compat import iteritems, itervalues, string_types, xrange
+from ._compat import itervalues, string_types, xrange
 from .model import DefaultMeta
 from . import utils
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,5 +1,3 @@
-import collections
-import datetime as dt
 import pytest
 from werkzeug.exceptions import NotFound
 


### PR DESCRIPTION
This is a stab at addressing #482. 

The problem with #485 seemed to be the serialization of the items (which from my understanding is a collection of rowProxy's from sqlalchemy). I attempted to add basic support for serialization of basic items people would query from the DB: int, float, datetimes (iso 8601 format), strings. 

The problem with #580 seemed to be lack of tests.

Look forward to hearing your feedback :)