### PR TITLE
Add Dyamic Filtering

### DIFF
--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -22,6 +22,22 @@ def test_no_app_bound(app):
         assert len(Foo.query.all()) == 1
 
 
+def test_dynamic_filtering_records(db, Todo):
+    # If an app was passed to the SQLAlchemy constructor,
+    # the query property is always available.
+    todo = Todo('Test', 'test_text')
+    db.session.add(todo)
+    db.session.commit()
+    assert len(Todo.query.dynamic_filter([(Todo.title, 'eq', 'Test'), (Todo.text, 'eq', 'test_text')]).all()) == 1
+
+def test_dynamic_filtering_no_records(db, Todo):
+    # If an app was passed to the SQLAlchemy constructor,
+    # the query property is always available.
+    todo = Todo('Test', 'test')
+    db.session.add(todo)
+    db.session.commit()
+    assert len(Todo.query.dynamic_filter([(Todo.text, 'eq', 'not_exists')]).all()) == 0
+
 def test_app_bound(db, Todo):
     # If an app was passed to the SQLAlchemy constructor,
     # the query property is always available.


### PR DESCRIPTION
Hi mates.

I've been working with filters for a while and always needed to use an utils to do the job. For example:
```py
@app.route('/places')
def places():
    places = Place.dynamic_filter(filters()).all()
    return render_template('places.html', places=places)

def filters():
    filters = [
        (Place.search_id, request.args.get('search_id_operation') or 'eq', request.args.get('search_id'))
    ]
    return [(key, op, value) for (key, op, value) in filters if value]
```

I was thinking that it will be nice to have in `flask-sqlalchemy` an util like this one.

```py
Todo.query.dynamic_filter([(Todo.title, 'eq', 'Test'), (Todo.text, 'eq', 'test_text')]).all()
```

What do you people think?