### PR TITLE
Fix TimeoutError when QueuePool limit is reached

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -849,7 +849,7 @@ class SQLAlchemy(object):
                 if response_or_exc is None:
                     self.session.commit()
 
-            self.session.remove()
+            db.session.close_all()
             return response_or_exc
 
     def apply_pool_defaults(self, app, options):


### PR DESCRIPTION
I got the Error: 'sqlalchemy.exc.TimeoutError: QueuePool limit of size 10 overflow 10 reached, connection timed out, timeout 30'.

To solve this problem I change line 852: self.session.remove() by
db.session.close_all().