### PR TITLE
Switch to azure pipelines with Linux, Mac, and Windows builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,86 @@
+trigger:
+  - 'master'
+  - '*.x'
+
+jobs:
+  - job: Flask-SQLAlchemy
+    variables:
+      vmImage: ubuntu-latest
+      python.version: '3.7'
+      python.architecture: 'x64'
+      TOXENV: 'py,coverage-ci'
+      publish.test.results: 'true'
+
+    strategy:
+      matrix:
+        Python37Linux:
+          python.version: '3.7'
+        Python37Windows:
+          python.version: '3.7'
+          vmImage: 'windows-latest'
+        Python37Mac:
+          python.version: '3.7'
+          vmImage: 'macos-latest'
+        Pypy3Linux:
+          python.version: 'pypy3'
+        Python36Linux:
+          python.version: '3.6'
+        Python35Linux:
+          python.version: '3.5'
+        Python27Linux:
+          python.version: '2.7'
+        Python27Windows:
+          python.version: '2.7'
+          vmImage: 'windows-latest'
+        DocsHtml:
+          TOXENV: 'docs-html'
+          publish.test.results: 'false'
+        Style:
+          TOXENV: stylecheck
+          publish.test.results: 'false'
+        VersionRange:
+          TOXENV: 'devel,lowest,coverage-ci'
+
+    pool:
+      vmImage: $[ variables.vmImage ]
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(python.version)
+          architecture: $(python.architecture)
+        displayName: Use Python $(python.version)
+
+      - script: pip --disable-pip-version-check install -U tox
+        displayName: Install tox
+
+      - script: tox -- --junitxml=test-results.xml tests examples
+        displayName: Run tox
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: test-results.xml
+          testRunTitle: $(Agent.JobName)
+        condition: eq(variables['publish.test.results'], 'true')
+        displayName: Publish test results
+
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: Cobertura
+          summaryFileLocation: coverage.xml
+        condition: eq(variables['publish.test.results'], 'true')
+        displayName: Publish coverage results
+
+  # Test on the nightly version of Python.
+  # Use a container since Azure Pipelines may not have the latest build.
+  - job: FlaskOnNightly
+    pool:
+      vmImage: ubuntu-latest
+    container: python:rc-stretch
+    steps:
+      - script: |
+          echo "##vso[task.prependPath]$HOME/.local/bin"
+          pip --disable-pip-version-check install --user -U tox
+        displayName: Install tox
+      - script: tox -e nightly
+        displayName: Run tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 os: linux
 dist: xenial
 language: python
-env: TOXENV=py,codecov
+env: TOXENV=py,coverage
 
 matrix:
   fast_finish: true
   include:
     - python: 2.7
-      env: TOXENV=py,py27-lowest,codecov
+      env: TOXENV=py,py27-lowest,coverage
     - python: 3.4
     - python: 3.5
     - python: 3.6
-      env: TOXENV=py,py36-lowest,codecov
+      env: TOXENV=py,py36-lowest,coverage
     - python: 3.7
-      env: TOXENV=py,py37-lowest,codecov
+      env: TOXENV=py,py37-lowest,coverage
     - python: 3.7
       env: TOXENV=docs
     - python: nightly

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     # Don't need to test all Python versions against lowest requirements.
     py{37,36,27}-lowest
     docs
-    coverage-report
+    coverage
 # This will only apply on a dev machine. We set this false for CI.
 skip_missing_interpreters = true
 
@@ -34,7 +34,7 @@ commands =
     python setup.py sdist
     twine check dist/*
 
-[testenv:coverage-report]
+[testenv:coverage]
 deps = coverage
 skip_install = true
 commands =
@@ -42,11 +42,10 @@ commands =
     coverage html
     coverage report
 
-[testenv:codecov]
-passenv = CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_*
-deps = codecov
+[testenv:coverage-ci]
+deps = coverage
 skip_install = true
 commands =
     coverage combine
-    codecov
+    coverage xml
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
-    pytest
+    pytest < 5.0
     coverage
     blinker
     mock


### PR DESCRIPTION
Resolves: #690 
- 

- Switches flask-sqlalchemy to Azure pipelines
- Enables Mac and Windows CI builds
- Switches coverage to be similar to other pallets projects