### PR TITLE
Removed conditional count from pagination

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -499,13 +499,8 @@ class BaseQuery(orm.Query):
         if not items and page != 1 and error_out:
             abort(404)
 
-        # No need to count if we're on the first page and there are fewer
-        # items than we expected or if count is disabled.
-
         if not count:
             total = None
-        elif page == 1 and len(items) < per_page:
-            total = len(items)
         else:
             total = self.order_by(None).count()
 


### PR DESCRIPTION
If you have duplicate results (which get deduped), `len(items)` always returns a value less than the per_page limit. This causes a bug whereby you have several pages of results, but the pagination metadata does not reveal this, and implies there is only one page of results.

The overhead from counting all results now, regardless of whether they fit onto a single page is worth considering, but using the `count ` flag can bypass this as before.