### PR TITLE
Subclass meta mixins from `type`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Version 2.4.4
+-------------
+
+Unreleased
+
+-   Change base class of meta mixins to ``type``. This fixes an issue
+    caused by a regression in CPython 3.8.4. :issue:`852`
+
+
 Version 2.4.3
 -------------
 

--- a/flask_sqlalchemy/model.py
+++ b/flask_sqlalchemy/model.py
@@ -59,7 +59,7 @@ def camel_to_snake_case(name):
     return camelcase_re.sub(_join, name).lstrip('_')
 
 
-class NameMetaMixin(object):
+class NameMetaMixin(type):
     def __init__(cls, name, bases, d):
         if should_set_tablename(cls):
             cls.__tablename__ = camel_to_snake_case(cls.__name__)
@@ -111,7 +111,7 @@ class NameMetaMixin(object):
             del cls.__tablename__
 
 
-class BindMetaMixin(object):
+class BindMetaMixin(type):
     def __init__(cls, name, bases, d):
         bind_key = (
             d.pop('__bind_key__', None)


### PR DESCRIPTION
This fixes regression introduced in Python 3.8.4, fixes #852 

All unit tests passed on Python 3.8.4:

```
tox -epy38
GLOB sdist-make: /app/setup.py
py38 inst-nodeps: /app/.tox/.tmp/package/1/Flask-SQLAlchemy-2.4.3.zip
py38 installed: attrs==19.3.0,blinker==1.4,click==7.1.2,coverage==5.2,Flask==1.1.2,Flask-SQLAlchemy @ file:///app/.tox/.tmp/package/1/Flask-SQLAlchemy-2.4.3.zip,itsdangerous==1.1.0,Jinja2==2.11.2,MarkupSafe==1.1.1,mock==4.0.2,more-itertools==8.4.0,packaging==20.4,pluggy==0.13.1,py==1.9.0,pyparsing==2.4.7,pytest==5.4.3,six==1.15.0,SQLAlchemy==1.3.18,wcwidth==0.2.5,Werkzeug==1.0.1
py38 run-test-pre: PYTHONHASHSEED='992667399'
py38 run-test: commands[0] | coverage run -p -m pytest --tb=short --basetemp=/app/.tox/py38/tmp
=============================== test session starts ================================
platform linux -- Python 3.8.4, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py38/.pytest_cache
rootdir: /app, inifile: setup.cfg, testpaths: tests
collected 72 items                                                                 

tests/test_basic_app.py ....                                                 [  5%]
tests/test_binds.py ....                                                     [ 11%]
tests/test_commit_on_teardown.py ..                                          [ 13%]
tests/test_config.py ..................                                      [ 38%]
tests/test_meta_data.py ..                                                   [ 41%]
tests/test_model_class.py ....                                               [ 47%]
tests/test_pagination.py .....                                               [ 54%]
tests/test_query_class.py ...                                                [ 58%]
tests/test_query_property.py ....                                            [ 63%]
tests/test_regressions.py ....                                               [ 69%]
tests/test_sessions.py ....                                                  [ 75%]
tests/test_signals.py ..                                                     [ 77%]
tests/test_sqlalchemy_includes.py .                                          [ 79%]
tests/test_table_name.py .............                                       [ 97%]
tests/test_utils.py ..                                                       [100%]

================================= warnings summary =================================
tests/test_commit_on_teardown.py::test_commit_on_success
tests/test_commit_on_teardown.py::test_roll_back_on_failure
  /app/flask_sqlalchemy/__init__.py:850: DeprecationWarning: 'COMMIT_ON_TEARDOWN' is deprecated and will be removed in version 3.1. Call 'db.session.commit()'` directly instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================== 72 passed, 2 warnings in 1.27s ==========================
_____________________________________ summary ______________________________________
  py38: commands succeeded
  congratulations :)
```