### PR TITLE
init_app now sets  the app attribute

### DIFF
--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -727,7 +727,6 @@ class SQLAlchemy:
         self.session = self.create_scoped_session(session_options)
         self.Model = self.make_declarative_base(model_class, metadata)
         self._engine_lock = Lock()
-        self.app = app
         self._engine_options = engine_options or {}
         _include_sqlalchemy(self, query_class)
 
@@ -814,6 +813,8 @@ class SQLAlchemy:
         of an application not initialized that way or connections will
         leak.
         """
+
+        self.app = app
 
         # We intentionally don't set self.app = app, to support multiple
         # applications. If the app is passed in the constructor,

--- a/tests/test_extension_class.py
+++ b/tests/test_extension_class.py
@@ -1,0 +1,14 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+def test_constructor_sets_app(app):
+    db = SQLAlchemy(app)
+
+    assert db.app is not None
+
+
+def test_init_app_sets_app(app):
+    db = SQLAlchemy()
+    db.init_app(app)
+
+    assert db.app is not None

--- a/tests/test_query_property.py
+++ b/tests/test_query_property.py
@@ -1,26 +1,6 @@
 import pytest
 from werkzeug.exceptions import NotFound
 
-from flask_sqlalchemy import SQLAlchemy
-
-
-def test_no_app_bound(app):
-    db = SQLAlchemy()
-    db.init_app(app)
-
-    class Foo(db.Model):
-        id = db.Column(db.Integer, primary_key=True)
-
-    # If no app is bound to the SQLAlchemy instance, a
-    # request context is required to access Model.query.
-    pytest.raises(RuntimeError, getattr, Foo, "query")
-    with app.test_request_context():
-        db.create_all()
-        foo = Foo()
-        db.session.add(foo)
-        db.session.commit()
-        assert len(Foo.query.all()) == 1
-
 
 def test_app_bound(db, Todo):
     # If an app was passed to the SQLAlchemy constructor,


### PR DESCRIPTION
Now calling init_app after constructing the flask extension behaves the same
as providing app to the constructor.
Also, setting the app attribute on the constructor only creates problems for the **empty** package and flask-empty boilerplate. If not setting app on **init_app** was by design and has a technical justification, please, let me know. 