### PR TITLE
Update config.rst

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -171,7 +171,7 @@ example, as suggested by the SQLAlchemy docs::
     convention = {
         "ix": 'ix_%(column_0_label)s',
         "uq": "uq_%(table_name)s_%(column_0_name)s",
-        "ck": "ck_%(table_name)s_%(constraint_name)s",
+        "ck": "ck_%(table_name)s_%(column_0_name)s",
         "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
         "pk": "pk_%(table_name)s"
     }


### PR DESCRIPTION
The current suggested Metadata naming_convention dictionary runs into issues on migrating Boolean columns in SQLite databases as described here (https://github.com/sqlalchemy/sqlalchemy/issues/3345) and here (https://github.com/sqlalchemy/sqlalchemy/issues/4784). If for some reason the original ck value is necessary, it might be useful to have an additional note indicating this as an alternative. Thanks for considering!