### PR TITLE
Initial Support for SQLAlchemy 1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Version 3.0.0
 
 Unreleased
 
+-   Add support for SQLAlchemy 1.4
 -   Drop support for Python 2, 3.4, and 3.5.
 -   Bump minimum version of Flask to 1.0.4.
 -   Bump minimum version of SQLAlchemy to 1.2.

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -17,8 +17,8 @@ from sqlalchemy import event
 from sqlalchemy import inspect
 from sqlalchemy import orm
 from sqlalchemy.engine.url import make_url
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.declarative import DeclarativeMeta
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.exc import UnmappedClassError
 from sqlalchemy.orm.session import Session as SessionBase
 


### PR DESCRIPTION
This is an initial PR to support SQLAlchemy 1.4. Since SQLAlchemy 1.4 is in _pre-release_ state at this time, the PR is initial until 1.4 is formally released. In this PR, there are no interface changes and support for SQLAlchemy 1.2+ is preserved. The PR addresses the underlaying SQLAlchemy changes which impacts Flask-SQLAlchemy.

All tests passed against SQLAlchemy `master` branch. Two tests don't pass against 1.4.0b3 though due to an issue with relationship dynamic loading that was fixed on `master` but not released yet:

* tests/test_query_class.py::test_default_query_class
* tests/test_query_class.py::test_custom_query_class

See https://github.com/sqlalchemy/sqlalchemy/issues/5981 for more details.

### Relevant issue

- #910: Update for new versions of SQLAlchemy

### Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
