### PR TITLE
Fix: Limit sqlalchemy dependency to <1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Unreleased
 
 -   Drop support for Python 2, 3.4, and 3.5.
 -   Bump minimum version of Flask to 1.0.4.
--   Bump minimum version of SQLAlchemy to 1.2.
+-   Bump minimum version of SQLAlchemy to 1.2 and restrict to < 1.4 `885`.
 -   Remove previously deprecated code.
 -   Set ``SQLALCHEMY_TRACK_MODIFICATIONS`` to ``False`` by default.
     :pr:`727`

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ with open("src/flask_sqlalchemy/__init__.py", encoding="utf8") as f:
 setup(
     name="Flask-SQLAlchemy",
     version=version,
-    install_requires=["Flask>=1.0.4", "SQLAlchemy>=1.2"],
+    install_requires=["Flask>=1.0.4", "SQLAlchemy<1.4,>=1.2"],
 )


### PR DESCRIPTION
This pull request addresses #885 until #919 is completed.

It ensures that sqlalchemy 1.4 is not pulled in as a dependency prior to adding support for it.

At present, the dependency on sqlalchemy >= 1.2 results in the latest release, 1.4, being added.
The module does not yet support sqlalchemy 1.4, resulting in new installations failing when using
local databases (#885).

- fixes #885

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.