### PR TITLE
Updated CamelCase to snake_case converter to cover more cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Unreleased
 -   Bump minimum version of Flask to 1.0.4.
 -   Bump minimum version of SQLAlchemy to 1.2.
 -   Remove previously deprecated code.
+-   The CamelCase to snake_case table name converter handles more
+    patterns correctly. If such a name was already created in the
+    database, either use Alembic to rename the table, or set
+    ``__tablename__`` to keep the old name. :issue:`406`
 -   Set ``SQLALCHEMY_TRACK_MODIFICATIONS`` to ``False`` by default.
     :pr:`727`
 -   Remove default ``'sqlite:///:memory:'`` setting for

--- a/src/flask_sqlalchemy/model.py
+++ b/src/flask_sqlalchemy/model.py
@@ -42,19 +42,9 @@ def should_set_tablename(cls):
     return True
 
 
-camelcase_re = re.compile(r"([A-Z]+)(?=[a-z0-9])")
-
-
 def camel_to_snake_case(name):
-    def _join(match):
-        word = match.group()
-
-        if len(word) > 1:
-            return f"_{word[:-1]}_{word[-1]}".lower()
-
-        return f"_{word.lower()}"
-
-    return camelcase_re.sub(_join, name).lstrip("_")
+    name = re.sub(r"((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))", r"_\1", name)
+    return name.lower().lstrip("_")
 
 
 class NameMetaMixin(type):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,3 +1,5 @@
+import random
+
 import sqlalchemy as sa
 from sqlalchemy.orm import sessionmaker
 
@@ -17,20 +19,15 @@ def test_default_session_scoping(app, db):
 
 
 def test_session_scoping_changing(app):
-    def scopefunc():
-        return id(dict())
+    db = SQLAlchemy(app, session_options={"scopefunc": random.random})
 
-    db = SQLAlchemy(app, session_options=dict(scopefunc=scopefunc))
-
-    class FOOBar(db.Model):
+    class Example(db.Model):
         id = db.Column(db.Integer, primary_key=True)
 
     db.create_all()
-
-    with app.test_request_context():
-        fb = FOOBar()
-        db.session.add(fb)
-        assert fb not in db.session  # because a new scope is generated on each call
+    fb = Example()
+    db.session.add(fb)
+    assert fb not in db.session  # because a new scope is generated on each call
 
 
 def test_insert_update_delete(db):

--- a/tests/test_table_name.py
+++ b/tests/test_table_name.py
@@ -4,6 +4,44 @@ import pytest
 from sqlalchemy.exc import ArgumentError
 from sqlalchemy.ext.declarative import declared_attr
 
+from flask_sqlalchemy.model import camel_to_snake_case
+
+
+@pytest.mark.parametrize(
+    ("name", "expect"),
+    [
+        ("CamelCase", "camel_case"),
+        ("Snake_case", "snake_case"),
+        ("HTMLLayout", "html_layout"),
+        ("LayoutHTML", "layout_html"),
+        ("HTTP2Request", "http2_request"),
+        ("ShoppingCartSession", "shopping_cart_session"),
+        ("ABC", "abc"),
+        ("PreABC", "pre_abc"),
+        ("ABCPost", "abc_post"),
+        ("PreABCPost", "pre_abc_post"),
+        ("HTTP2RequestSession", "http2_request_session"),
+        ("UserST4", "user_st4"),
+        (
+            "HTTP2ClientType3EncoderParametersSSE",
+            "http2_client_type3_encoder_parameters_sse",
+        ),
+        (
+            "LONGName4TestingCamelCase2snake_caseXYZ",
+            "long_name4_testing_camel_case2snake_case_xyz",
+        ),
+        ("FooBarSSE2", "foo_bar_sse2"),
+        ("AlarmMessageSS2SignalTransformer", "alarm_message_ss2_signal_transformer"),
+        ("AstV2Node", "ast_v2_node"),
+        ("HTTPResponseCodeXYZ", "http_response_code_xyz"),
+        ("get2HTTPResponse123Code", "get2_http_response123_code"),
+        # ("getHTTPresponseCode", "get_htt_presponse_code"),
+        # ("__test__Method", "test___method"),
+    ],
+)
+def test_camel_to_snake_case(name, expect):
+    assert camel_to_snake_case(name) == expect
+
 
 def test_name(db):
     class FOOBar(db.Model):


### PR DESCRIPTION
I have updated the regex pattern for converting CamelCase table names to snake_case. I've also compared this with #617. Detailed results of the comparison can be found [here](http://bit.ly/test-case-analysis). 

`tests/test_basic_app.py::test_sqlite_relative_path` fails for `SQLAlchemy == 1.4.0` giving #885. All tests pass with older `SQLAlchemy` version.

- fixes #406 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
