### PR TITLE
Update __init__.py

### DIFF
--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -621,7 +621,8 @@ class _EngineConnector:
 
         # Give the config options set by a developer explicitly priority
         # over decisions FSA makes.
-        options.update(self._app.config["SQLALCHEMY_ENGINE_OPTIONS"])
+        if self._app.config["SQLALCHEMY_ENGINE_OPTIONS"]:
+            options.update(self._app.config["SQLALCHEMY_ENGINE_OPTIONS"])
         # Give options set in SQLAlchemy.__init__() ultimate priority
         options.update(self._sa._engine_options)
         return sa_url, options


### PR DESCRIPTION
check if SQLALCHEMY_ENGINE_OPTIONS is set

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

treats `SQLALCHEMY_ENGINE_OPTIONS` as an optional config parameter. Right now setting `SQLALCHEMY_ENGINE_OPTIONS` is mandatory, even if set to {}.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #948

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

-->

