### PR TITLE
fix: session get bind signature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,14 @@ Unreleased
     ``db.session.commit()`` directly instead. :issue:`216`
 
 
+Version 2.5.2
+-------------
+
+Unreleased
+
+-   Fix session ``get_bind`` signature for SQLAlchemy 1.4. :issue:`953`
+
+
 Version 2.5.1
 -------------
 

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -172,7 +172,14 @@ class SignallingSession(SessionBase):
             **options,
         )
 
-    def get_bind(self, mapper=None, **kwargs):
+    def get_bind(
+        self,
+        mapper=None,
+        clause=None,
+        bind=None,
+        _sa_skip_events=None,
+        _sa_skip_for_implicit_returning=False,
+    ):
         """Return the engine or connection for a given model or
         table, using the ``__bind_key__`` if it is set.
         """
@@ -191,7 +198,13 @@ class SignallingSession(SessionBase):
                 state = get_state(self.app)
                 return state.db.get_engine(self.app, bind=bind_key)
 
-        return super().get_bind(mapper, **kwargs)
+        return super().get_bind(
+            mapper=mapper,
+            clause=clause,
+            bind=bind,
+            _sa_skip_events=_sa_skip_events,
+            _sa_skip_for_implicit_returning=_sa_skip_for_implicit_returning,
+        )
 
 
 class _SessionSignalEvents:

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -175,10 +175,8 @@ class SignallingSession(SessionBase):
     def get_bind(
         self,
         mapper=None,
-        clause=None,
-        bind=None,
-        _sa_skip_events=None,
-        _sa_skip_for_implicit_returning=False,
+        *args,
+        **kwargs,
     ):
         """Return the engine or connection for a given model or
         table, using the ``__bind_key__`` if it is set.
@@ -199,11 +197,9 @@ class SignallingSession(SessionBase):
                 return state.db.get_engine(self.app, bind=bind_key)
 
         return super().get_bind(
-            mapper=mapper,
-            clause=clause,
-            bind=bind,
-            _sa_skip_events=_sa_skip_events,
-            _sa_skip_for_implicit_returning=_sa_skip_for_implicit_returning,
+            mapper,
+            *args,
+            **kwargs,
         )
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,6 +1,7 @@
 import random
 
 import sqlalchemy as sa
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 from flask_sqlalchemy import SQLAlchemy
@@ -59,3 +60,8 @@ def test_insert_update_delete(db):
 
 def test_listen_to_session_event(db):
     sa.event.listen(db.session, "after_commit", lambda session: None)
+
+
+def test_session_get_bind(app, db):
+    with app.test_request_context():
+        assert isinstance(db.session.get_bind(), Engine)


### PR DESCRIPTION
The `SignallingSession` `get_bind` is being called without any parameters, this is probably due to the new SQLAlchemy proxied mechanism for registering scoped sessions 

```
(None, None, None, None, False) {}
```

This is a simple fix that just uses the exact method signature from SQLAlchemy for get_bind of the current session

- fixes #953

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
