### PR TITLE
fix(2.x): session get bind signature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 2.5.2
+-------------
+
+Unreleased
+
+-   Fix session ``get_bind`` signature for SQLAlchemy 1.4. :issue:`953`
+
+
 Version 2.5.1
 -------------
 

--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -184,7 +184,12 @@ class SignallingSession(SessionBase):
             bind=bind, binds=binds, **options
         )
 
-    def get_bind(self, mapper=None, clause=None):
+    def get_bind(
+        self,
+        mapper=None,
+        *args,
+        **kwargs
+    ):
         """Return the engine or connection for a given model or
         table, using the ``__bind_key__`` if it is set.
         """
@@ -202,7 +207,12 @@ class SignallingSession(SessionBase):
             if bind_key is not None:
                 state = get_state(self.app)
                 return state.db.get_engine(self.app, bind=bind_key)
-        return SessionBase.get_bind(self, mapper, clause)
+        return SessionBase.get_bind(
+            self,
+            mapper,
+            *args,
+            **kwargs
+        )
 
 
 class _SessionSignalEvents(object):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sa
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
 import flask_sqlalchemy as fsa
@@ -63,3 +64,8 @@ def test_insert_update_delete(db):
 
 def test_listen_to_session_event(db):
     sa.event.listen(db.session, 'after_commit', lambda session: None)
+
+
+def test_session_get_bind(app, db):
+    with app.test_request_context():
+        assert isinstance(db.session.get_bind(), Engine)


### PR DESCRIPTION
The SignallingSession get_bind is being called without any parameters, this is probably due to the new SQLAlchemy proxied mechanism for registering scoped sessions

(None, None, None, None, False) {}
This is a simple fix that just uses the exact method signature from SQLAlchemy for get_bind of the current session

fixes Possible issue on session get_bind #953

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
