### PR TITLE
Change the default MySQL charset to utf8mb4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Unreleased
 -   Deprecate ``SQLALCHEMY_COMMIT_ON_TEARDOWN`` as it can cause various
     design issues that are difficult to debug. Call
     ``db.session.commit()`` directly instead. :issue:`216`
+-   Change the default MySQL character set to "utf8mb4". :issue:`875`
 
 
 Version 2.5.1

--- a/src/flask_sqlalchemy/__init__.py
+++ b/src/flask_sqlalchemy/__init__.py
@@ -894,13 +894,16 @@ class SQLAlchemy:
         The default implementation provides some defaults for things
         like pool sizes for MySQL and SQLite.
 
+        .. versionchanged:: 3.0
+            Change the default MySQL character set to "utf8mb4".
+
         .. versionchanged:: 2.5
             Returns ``(sa_url, options)``. SQLAlchemy 1.4 made the URL
             immutable, so any changes to it must now be passed back up
             to the original caller.
         """
         if sa_url.drivername.startswith("mysql"):
-            sa_url = _sa_url_query_setdefault(sa_url, charset="utf8")
+            sa_url = _sa_url_query_setdefault(sa_url, charset="utf8mb4")
 
             if sa_url.drivername != "mysql+gaerdbms":
                 options.setdefault("pool_size", 10)


### PR DESCRIPTION
In MySQL 8, the `utf8` charset alias to `utf8mb3` (deprecated), and will be an alias to `utf8mb4` (default value) in the future releases, so it's better to change it to `utf8mb4` explicitly ([ref](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-sets.html)).

- fixes #875

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
